### PR TITLE
XDOCKER-165: Add image for XWiki on MariaDB (docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ This is exactly similar to starting MySQL and you should thus follow exactly the
 Full command example:
 
 ```console
-docker run --net=xwiki-nw --name mysql-xwiki -v /my/path/mariadb:/var/lib/mysql -v /my/path/mariadb-init:/docker-entrypoint-initdb.d -e MYSQL_ROOT_PASSWORD=xwiki -e MYSQL_USER=xwiki -e MYSQL_PASSWORD=xwiki -e MYSQL_DATABASE=xwiki -d mariadb:10.5 --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --explicit-defaults-for-timestamp=1
+docker run --net=xwiki-nw --name mariadb-xwiki -v /my/path/mariadb:/var/lib/mysql -v /my/path/mariadb-init:/docker-entrypoint-initdb.d -e MARIADB_ROOT_PASSWORD=xwiki -e MARIADB_USER=xwiki -e MARIADB_PASSWORD=xwiki -e MARIADB_DATABASE=xwiki -d mariadb:10.5 --collation-server=utf8mb4_bin --explicit-defaults-for-timestamp=1
 ```
 
 #### Starting PostgreSQL
@@ -157,6 +157,11 @@ For MySQL:
 
 ```console
 docker run --net=xwiki-nw --name xwiki -p 8080:8080 -v /my/path/xwiki:/usr/local/xwiki -e DB_USER=xwiki -e DB_PASSWORD=xwiki -e DB_DATABASE=xwiki -e DB_HOST=mysql-xwiki xwiki:lts-mysql-tomcat
+```
+
+For MariaDB:
+```console
+docker run --net=xwiki-nw --name xwiki -p 8080:8080 -v /my/path/xwiki:/usr/local/xwiki -e DB_USER=xwiki -e DB_PASSWORD=xwiki -e DB_DATABASE=xwiki -e DB_HOST=mariadb-xwiki xwiki:stable-mariadb
 ```
 
 For PostgreSQL:


### PR DESCRIPTION
Thank you for putting up a MariaDB based Docker Library official image. As the Docker Library maintainer for MariaDB I felt honoured to try it out.

The things I've changed in this PR are:

* Add a section for starting XWiki with MariaDB
* Changes starting mariadb using name mariadb-xwiki
* Used MARIADB_* environment variables for initialization of MariaDB
  container.
* --character-set-server=utf8mb4 is the default in MariaDB container,
  omit for simplicity.


Things that might be unnecessary are:

/my/path/{mariadb,mysql}-init, both MySQL and MariaDB use the environment variables `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_DATABASE` and `MARIADB_*` equivalents to create `GRANT ALL on $MYSQL_DATABASE.* TO $MYSQL_USER@%`. Is there some global privilege required?

As xwiki (as far as I see) doesn't use the root password, perhaps using `MARIADB_RANDOM_ROOT_PASSWORD=1` / `MYSQL_RANDOM_ROOT_PASSWORD=1` to hide its use from ordinary users.

Collation - the setting to utf8_bin, is this a need for case sensitive collations?

You are welcome to use the container images from the pre-release in your CI to ensure that we don't regress anything in the server that affects xwiki - https://mariadb.org/new-service-quay-io-mariadb-foundation-mariadb-devel/.