### PR TITLE
[XDOCKER-225] Enable path parameter in jdbc connection 

### DIFF
--- a/14/mysql-tomcat/Dockerfile
+++ b/14/mysql-tomcat/Dockerfile
@@ -103,6 +103,7 @@ VOLUME /usr/local/xwiki
 #            configure xwiki's hibernate.cfg.xml file.
 # - CONTEXT_PATH: The name of the context path under which XWiki will be deployed in Tomcat. If not specified then it'll
 #                 be deployed as ROOT.
+# - ADDITIONAL_JDBC_PARAM: Additional JDBC parameters. An example could be '&allowPublicKeyRetrieval=true'
 
 # Example:
 #   docker run -it -e "DB_USER=xwiki" -e "DB_PASSWORD=xwiki" <imagename>

--- a/14/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/14/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -127,6 +127,7 @@ function configure() {
   safesed "replacepassword" $DB_PASSWORD /usr/local/tomcat/webapps/$CONTEXT_PATH/WEB-INF/hibernate.cfg.xml
   safesed "replacecontainer" $DB_HOST /usr/local/tomcat/webapps/$CONTEXT_PATH/WEB-INF/hibernate.cfg.xml
   safesed "replacedatabase" $DB_DATABASE /usr/local/tomcat/webapps/$CONTEXT_PATH/WEB-INF/hibernate.cfg.xml
+  safesed "replacejdbcparam" $ADDITIONAL_JDBC_PARAM /usr/local/tomcat/webapps/$CONTEXT_PATH/WEB-INF/hibernate.cfg.xml
 
   # Set any non-default main wiki database name in the xwiki.cfg file.
   if [ "$DB_DATABASE" != "xwiki" ]; then

--- a/14/postgres-tomcat/xwiki/hibernate.cfg.xml
+++ b/14/postgres-tomcat/xwiki/hibernate.cfg.xml
@@ -87,7 +87,7 @@
            - if you want the main wiki database to be different than "xwiki" (or "public" in schema mode)
              you will also have to set the property xwiki.db in xwiki.cfg file
     -->
-    <property name="connection.url">jdbc:postgresql://replacecontainer:5432/replacedatabase</property>
+    <property name="connection.url">jdbc:postgresql://replacecontainer:5432/replacedatabasereplacejdbcparam</property>
     <property name="connection.username">replaceuser</property>
     <property name="connection.password">replacepassword</property>
     <property name="connection.driver_class">org.postgresql.Driver</property>


### PR DESCRIPTION
When connecting to a MySQL 8.0 database, a allowPublicKeyRetrieval path parameter is required in the jdbc connection. This cannot be set via environmental variables, causing

`java.sql.SQLNonTransientConnectionException: Public Key Retrieval is not allowed. `

https://jira.xwiki.org/browse/XDOCKER-225