### PR TITLE
Wrong docker-compose definition using container name instead of service name? (Update docker-compose content inside README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ services:
     environment:
       - DB_USER=xwiki
       - DB_PASSWORD=xwiki
-      - DB_HOST=xwiki-mariadb-db
+      - DB_HOST=db
     volumes:
       - xwiki-data:/usr/local/xwiki
     networks:
@@ -308,7 +308,7 @@ services:
     environment:
       - DB_USER=xwiki
       - DB_PASSWORD=xwiki
-      - DB_HOST=xwiki-postgres-db
+      - DB_HOST=db
     volumes:
       - xwiki-data:/usr/local/xwiki
     networks:


### PR DESCRIPTION
Doesn't DB_HOST need to be set to the service name instead of the container name?

At least for me, firing up the containers only worked after I changed this to service name (`DB_HOST=db` instead of, e.g., `DB_HOST=xwiki-mariadb-db`).

Before, I would get some like 25.000 java exceptions and errors on initial container start-up.