### PR TITLE
Add note regarding potential problems with mounting read-only config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ where:
 Notes: 
 * In the past, the first 3 configuration files listed above (`xwiki.cfg`, `xwiki.properties` and `hibernate.cfg.xml`) had a special handling, and they were copied automatically on the first XWiki container start, from the XWiki image into the local permanent directory. This was removed starting with XWiki 16.6.0/15.10.12. However, in order to preserve backward compatibility, if these files are found in the permanent directory, they are copied on container start to their location inside the container.
 * It's recommended to only map volumes for configuration files that you need to customize. This is because when you upgrade you'll need to perform a merge between XWiki's default configuration files and the ones you modified. If you haven't modified them, then there's no merge to do. 
+* The entrypoint script modifies some of the configuration files based on the environment variables provided. As a result, a read-only mount (e.g. when using Kubernetes config maps) might not function correctly in some cases. For custom `xwiki.cfg`, `xwiki.properties` and `hibernate.cfg.xml` configurations, the issue can be avoided by utilizing the before mentioned legacy mount into the permanent directory.
 
 ### Example for `docker run`
 


### PR DESCRIPTION
The entrypoint script modifies certain configuration files based on the provided environment variables. This behavior can lead to issues in environments where configuration files are mounted as read-only (e.g., via Kubernetes ConfigMaps).
This commit adds a note to the configuration section to help users identify and troubleshoot such issues more quickly. It also provides a suggested workaround for affected files.