### PR TITLE
XDOCKER-220: Incorrect path for extraction of Solr configuration JAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ docker run \
   --net=xwiki-nw \
   --name solr-xwiki \
   -v /path/to/solr/init/directory:/docker-entrypoint-initdb.d \
-  -v /my/path/solr:/opt/solr/server/solr/xwiki \
+  -v /my/path/solr:/var/solr/data/xwiki \
   -d solr:9
 ```
 
@@ -623,7 +623,7 @@ services:
     container_name: xwiki-index
     volumes:
       - ./solr:/docker-entrypoint-initdb.d
-      - solr-data:/opt/solr/server/solr
+      - solr-data:/var/solr
     networks:
       - bridge
 volumes:

--- a/contrib/solr/solr-init.sh
+++ b/contrib/solr/solr-init.sh
@@ -10,7 +10,7 @@
 # - At run time, before starting Solr, the container will execute scripts in the /docker-entrypoint-initdb.d/ directory.
 
 cd /docker-entrypoint-initdb.d/
-location='/opt/solr/server/solr/'
+location='/var/solr/data/'
 
 # Verify the existence of a singular XWiki Solr configuration jar
 jars=$(find . -type f -name *.jar | wc -l)


### PR DESCRIPTION
* Fixed the Solr home path used by solr-init.sh and the external-Solr README examples: since Solr 8.x the official image uses SOLR_HOME under /var/solr (cores in /var/solr/data), not the legacy /opt/solr/server/solr. With the old path the XWiki config JAR was extracted where Solr never reads it, so the xwiki core was not created.