### PR TITLE
XDOCKER-183: It's not really possible anymore to properly configure a remote Solr using variables since XWiki 12.2

### DIFF
--- a/16/mariadb-tomcat/xwiki/docker-entrypoint.sh
+++ b/16/mariadb-tomcat/xwiki/docker-entrypoint.sh
@@ -124,8 +124,7 @@ function configure() {
   file_env 'DB_PASSWORD' 'xwiki'
   file_env 'DB_HOST' 'db'
   file_env 'DB_DATABASE' 'xwiki'
-  file_env 'INDEX_HOST' 'localhost'
-  file_env 'INDEX_PORT' '8983'
+  file_env 'SOLR_BASE_URL' ''
   file_env 'JDBC_PARAMS' '?useSSL=false'
 
   echo "  Deploying XWiki in the '$CONTEXT_PATH' context"
@@ -153,13 +152,16 @@ function configure() {
   echo '  Configure libreoffice...'
   xwiki_set_properties 'openoffice.autoStart' 'true'
 
-  if [ $INDEX_HOST != 'localhost' ]; then
+  # Configure a remote Solr instance when SOLR_BASE_URL is set (empty by default, meaning the embedded Solr is
+  # used). SOLR_BASE_URL holds the full Solr base URL, so it can carry the scheme (e.g. https), a custom path and
+  # the port.
+  if [ -n "$SOLR_BASE_URL" ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
     # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
     # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
     # deprecated and only configures the search core, which breaks the other cores.
-    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
+    xwiki_set_properties 'solr.remote.baseURL' "$SOLR_BASE_URL"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/16/mariadb-tomcat/xwiki/docker-entrypoint.sh
+++ b/16/mariadb-tomcat/xwiki/docker-entrypoint.sh
@@ -156,7 +156,10 @@ function configure() {
   if [ $INDEX_HOST != 'localhost' ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
-    xwiki_set_properties 'solr.remote.url' "http://$INDEX_HOST:$INDEX_PORT/solr/xwiki"
+    # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
+    # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
+    # deprecated and only configures the search core, which breaks the other cores.
+    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/16/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/16/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -124,8 +124,7 @@ function configure() {
   file_env 'DB_PASSWORD' 'xwiki'
   file_env 'DB_HOST' 'db'
   file_env 'DB_DATABASE' 'xwiki'
-  file_env 'INDEX_HOST' 'localhost'
-  file_env 'INDEX_PORT' '8983'
+  file_env 'SOLR_BASE_URL' ''
   file_env 'JDBC_PARAMS' '?useSSL=false&amp;connectionTimeZone=LOCAL&amp;allowPublicKeyRetrieval=true'
 
   echo "  Deploying XWiki in the '$CONTEXT_PATH' context"
@@ -153,13 +152,16 @@ function configure() {
   echo '  Configure libreoffice...'
   xwiki_set_properties 'openoffice.autoStart' 'true'
 
-  if [ $INDEX_HOST != 'localhost' ]; then
+  # Configure a remote Solr instance when SOLR_BASE_URL is set (empty by default, meaning the embedded Solr is
+  # used). SOLR_BASE_URL holds the full Solr base URL, so it can carry the scheme (e.g. https), a custom path and
+  # the port.
+  if [ -n "$SOLR_BASE_URL" ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
     # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
     # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
     # deprecated and only configures the search core, which breaks the other cores.
-    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
+    xwiki_set_properties 'solr.remote.baseURL' "$SOLR_BASE_URL"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/16/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/16/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -156,7 +156,10 @@ function configure() {
   if [ $INDEX_HOST != 'localhost' ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
-    xwiki_set_properties 'solr.remote.url' "http://$INDEX_HOST:$INDEX_PORT/solr/xwiki"
+    # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
+    # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
+    # deprecated and only configures the search core, which breaks the other cores.
+    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/16/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/16/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -124,8 +124,7 @@ function configure() {
   file_env 'DB_PASSWORD' 'xwiki'
   file_env 'DB_HOST' 'db'
   file_env 'DB_DATABASE' 'xwiki'
-  file_env 'INDEX_HOST' 'localhost'
-  file_env 'INDEX_PORT' '8983'
+  file_env 'SOLR_BASE_URL' ''
   file_env 'JDBC_PARAMS' '?'
 
   echo "  Deploying XWiki in the '$CONTEXT_PATH' context"
@@ -150,13 +149,16 @@ function configure() {
   echo '  Configure libreoffice...'
   xwiki_set_properties 'openoffice.autoStart' 'true'
 
-  if [ $INDEX_HOST != 'localhost' ]; then
+  # Configure a remote Solr instance when SOLR_BASE_URL is set (empty by default, meaning the embedded Solr is
+  # used). SOLR_BASE_URL holds the full Solr base URL, so it can carry the scheme (e.g. https), a custom path and
+  # the port.
+  if [ -n "$SOLR_BASE_URL" ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
     # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
     # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
     # deprecated and only configures the search core, which breaks the other cores.
-    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
+    xwiki_set_properties 'solr.remote.baseURL' "$SOLR_BASE_URL"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/16/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/16/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -153,7 +153,10 @@ function configure() {
   if [ $INDEX_HOST != 'localhost' ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
-    xwiki_set_properties 'solr.remote.url' "http://$INDEX_HOST:$INDEX_PORT/solr/xwiki"
+    # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
+    # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
+    # deprecated and only configures the search core, which breaks the other cores.
+    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/17/mariadb-tomcat/xwiki/docker-entrypoint.sh
+++ b/17/mariadb-tomcat/xwiki/docker-entrypoint.sh
@@ -124,8 +124,7 @@ function configure() {
   file_env 'DB_PASSWORD' 'xwiki'
   file_env 'DB_HOST' 'db'
   file_env 'DB_DATABASE' 'xwiki'
-  file_env 'INDEX_HOST' 'localhost'
-  file_env 'INDEX_PORT' '8983'
+  file_env 'SOLR_BASE_URL' ''
   file_env 'JDBC_PARAMS' '?useSSL=false'
 
   echo "  Deploying XWiki in the '$CONTEXT_PATH' context"
@@ -153,13 +152,16 @@ function configure() {
   echo '  Configure libreoffice...'
   xwiki_set_properties 'openoffice.autoStart' 'true'
 
-  if [ $INDEX_HOST != 'localhost' ]; then
+  # Configure a remote Solr instance when SOLR_BASE_URL is set (empty by default, meaning the embedded Solr is
+  # used). SOLR_BASE_URL holds the full Solr base URL, so it can carry the scheme (e.g. https), a custom path and
+  # the port.
+  if [ -n "$SOLR_BASE_URL" ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
     # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
     # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
     # deprecated and only configures the search core, which breaks the other cores.
-    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
+    xwiki_set_properties 'solr.remote.baseURL' "$SOLR_BASE_URL"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/17/mariadb-tomcat/xwiki/docker-entrypoint.sh
+++ b/17/mariadb-tomcat/xwiki/docker-entrypoint.sh
@@ -156,7 +156,10 @@ function configure() {
   if [ $INDEX_HOST != 'localhost' ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
-    xwiki_set_properties 'solr.remote.url' "http://$INDEX_HOST:$INDEX_PORT/solr/xwiki"
+    # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
+    # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
+    # deprecated and only configures the search core, which breaks the other cores.
+    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/17/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/17/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -124,8 +124,7 @@ function configure() {
   file_env 'DB_PASSWORD' 'xwiki'
   file_env 'DB_HOST' 'db'
   file_env 'DB_DATABASE' 'xwiki'
-  file_env 'INDEX_HOST' 'localhost'
-  file_env 'INDEX_PORT' '8983'
+  file_env 'SOLR_BASE_URL' ''
   file_env 'JDBC_PARAMS' '?useSSL=false&amp;connectionTimeZone=LOCAL&amp;allowPublicKeyRetrieval=true'
 
   echo "  Deploying XWiki in the '$CONTEXT_PATH' context"
@@ -153,13 +152,16 @@ function configure() {
   echo '  Configure libreoffice...'
   xwiki_set_properties 'openoffice.autoStart' 'true'
 
-  if [ $INDEX_HOST != 'localhost' ]; then
+  # Configure a remote Solr instance when SOLR_BASE_URL is set (empty by default, meaning the embedded Solr is
+  # used). SOLR_BASE_URL holds the full Solr base URL, so it can carry the scheme (e.g. https), a custom path and
+  # the port.
+  if [ -n "$SOLR_BASE_URL" ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
     # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
     # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
     # deprecated and only configures the search core, which breaks the other cores.
-    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
+    xwiki_set_properties 'solr.remote.baseURL' "$SOLR_BASE_URL"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/17/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/17/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -156,7 +156,10 @@ function configure() {
   if [ $INDEX_HOST != 'localhost' ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
-    xwiki_set_properties 'solr.remote.url' "http://$INDEX_HOST:$INDEX_PORT/solr/xwiki"
+    # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
+    # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
+    # deprecated and only configures the search core, which breaks the other cores.
+    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/17/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/17/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -124,8 +124,7 @@ function configure() {
   file_env 'DB_PASSWORD' 'xwiki'
   file_env 'DB_HOST' 'db'
   file_env 'DB_DATABASE' 'xwiki'
-  file_env 'INDEX_HOST' 'localhost'
-  file_env 'INDEX_PORT' '8983'
+  file_env 'SOLR_BASE_URL' ''
   file_env 'JDBC_PARAMS' '?'
 
   echo "  Deploying XWiki in the '$CONTEXT_PATH' context"
@@ -150,13 +149,16 @@ function configure() {
   echo '  Configure libreoffice...'
   xwiki_set_properties 'openoffice.autoStart' 'true'
 
-  if [ $INDEX_HOST != 'localhost' ]; then
+  # Configure a remote Solr instance when SOLR_BASE_URL is set (empty by default, meaning the embedded Solr is
+  # used). SOLR_BASE_URL holds the full Solr base URL, so it can carry the scheme (e.g. https), a custom path and
+  # the port.
+  if [ -n "$SOLR_BASE_URL" ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
     # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
     # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
     # deprecated and only configures the search core, which breaks the other cores.
-    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
+    xwiki_set_properties 'solr.remote.baseURL' "$SOLR_BASE_URL"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/17/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/17/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -153,7 +153,10 @@ function configure() {
   if [ $INDEX_HOST != 'localhost' ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
-    xwiki_set_properties 'solr.remote.url' "http://$INDEX_HOST:$INDEX_PORT/solr/xwiki"
+    # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
+    # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
+    # deprecated and only configures the search core, which breaks the other cores.
+    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/18.4/mariadb-tomcat/xwiki/docker-entrypoint.sh
+++ b/18.4/mariadb-tomcat/xwiki/docker-entrypoint.sh
@@ -124,8 +124,7 @@ function configure() {
   file_env 'DB_PASSWORD' 'xwiki'
   file_env 'DB_HOST' 'db'
   file_env 'DB_DATABASE' 'xwiki'
-  file_env 'INDEX_HOST' 'localhost'
-  file_env 'INDEX_PORT' '8983'
+  file_env 'SOLR_BASE_URL' ''
   file_env 'JDBC_PARAMS' '?useSSL=false'
 
   echo "  Deploying XWiki in the '$CONTEXT_PATH' context"
@@ -153,13 +152,16 @@ function configure() {
   echo '  Configure libreoffice...'
   xwiki_set_properties 'openoffice.autoStart' 'true'
 
-  if [ $INDEX_HOST != 'localhost' ]; then
+  # Configure a remote Solr instance when SOLR_BASE_URL is set (empty by default, meaning the embedded Solr is
+  # used). SOLR_BASE_URL holds the full Solr base URL, so it can carry the scheme (e.g. https), a custom path and
+  # the port.
+  if [ -n "$SOLR_BASE_URL" ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
     # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
     # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
     # deprecated and only configures the search core, which breaks the other cores.
-    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
+    xwiki_set_properties 'solr.remote.baseURL' "$SOLR_BASE_URL"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/18.4/mariadb-tomcat/xwiki/docker-entrypoint.sh
+++ b/18.4/mariadb-tomcat/xwiki/docker-entrypoint.sh
@@ -156,7 +156,10 @@ function configure() {
   if [ $INDEX_HOST != 'localhost' ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
-    xwiki_set_properties 'solr.remote.url' "http://$INDEX_HOST:$INDEX_PORT/solr/xwiki"
+    # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
+    # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
+    # deprecated and only configures the search core, which breaks the other cores.
+    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/18.4/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/18.4/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -124,8 +124,7 @@ function configure() {
   file_env 'DB_PASSWORD' 'xwiki'
   file_env 'DB_HOST' 'db'
   file_env 'DB_DATABASE' 'xwiki'
-  file_env 'INDEX_HOST' 'localhost'
-  file_env 'INDEX_PORT' '8983'
+  file_env 'SOLR_BASE_URL' ''
   file_env 'JDBC_PARAMS' '?useSSL=false&amp;connectionTimeZone=LOCAL&amp;allowPublicKeyRetrieval=true'
 
   echo "  Deploying XWiki in the '$CONTEXT_PATH' context"
@@ -153,13 +152,16 @@ function configure() {
   echo '  Configure libreoffice...'
   xwiki_set_properties 'openoffice.autoStart' 'true'
 
-  if [ $INDEX_HOST != 'localhost' ]; then
+  # Configure a remote Solr instance when SOLR_BASE_URL is set (empty by default, meaning the embedded Solr is
+  # used). SOLR_BASE_URL holds the full Solr base URL, so it can carry the scheme (e.g. https), a custom path and
+  # the port.
+  if [ -n "$SOLR_BASE_URL" ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
     # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
     # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
     # deprecated and only configures the search core, which breaks the other cores.
-    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
+    xwiki_set_properties 'solr.remote.baseURL' "$SOLR_BASE_URL"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/18.4/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/18.4/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -156,7 +156,10 @@ function configure() {
   if [ $INDEX_HOST != 'localhost' ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
-    xwiki_set_properties 'solr.remote.url' "http://$INDEX_HOST:$INDEX_PORT/solr/xwiki"
+    # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
+    # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
+    # deprecated and only configures the search core, which breaks the other cores.
+    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/18.4/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/18.4/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -124,8 +124,7 @@ function configure() {
   file_env 'DB_PASSWORD' 'xwiki'
   file_env 'DB_HOST' 'db'
   file_env 'DB_DATABASE' 'xwiki'
-  file_env 'INDEX_HOST' 'localhost'
-  file_env 'INDEX_PORT' '8983'
+  file_env 'SOLR_BASE_URL' ''
   file_env 'JDBC_PARAMS' '?'
 
   echo "  Deploying XWiki in the '$CONTEXT_PATH' context"
@@ -150,13 +149,16 @@ function configure() {
   echo '  Configure libreoffice...'
   xwiki_set_properties 'openoffice.autoStart' 'true'
 
-  if [ $INDEX_HOST != 'localhost' ]; then
+  # Configure a remote Solr instance when SOLR_BASE_URL is set (empty by default, meaning the embedded Solr is
+  # used). SOLR_BASE_URL holds the full Solr base URL, so it can carry the scheme (e.g. https), a custom path and
+  # the port.
+  if [ -n "$SOLR_BASE_URL" ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
     # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
     # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
     # deprecated and only configures the search core, which breaks the other cores.
-    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
+    xwiki_set_properties 'solr.remote.baseURL' "$SOLR_BASE_URL"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/18.4/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/18.4/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -153,7 +153,10 @@ function configure() {
   if [ $INDEX_HOST != 'localhost' ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
-    xwiki_set_properties 'solr.remote.url' "http://$INDEX_HOST:$INDEX_PORT/solr/xwiki"
+    # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
+    # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
+    # deprecated and only configures the search core, which breaks the other cores.
+    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/18/mariadb-tomcat/xwiki/docker-entrypoint.sh
+++ b/18/mariadb-tomcat/xwiki/docker-entrypoint.sh
@@ -124,8 +124,7 @@ function configure() {
   file_env 'DB_PASSWORD' 'xwiki'
   file_env 'DB_HOST' 'db'
   file_env 'DB_DATABASE' 'xwiki'
-  file_env 'INDEX_HOST' 'localhost'
-  file_env 'INDEX_PORT' '8983'
+  file_env 'SOLR_BASE_URL' ''
   file_env 'JDBC_PARAMS' '?useSSL=false'
 
   echo "  Deploying XWiki in the '$CONTEXT_PATH' context"
@@ -153,13 +152,16 @@ function configure() {
   echo '  Configure libreoffice...'
   xwiki_set_properties 'openoffice.autoStart' 'true'
 
-  if [ $INDEX_HOST != 'localhost' ]; then
+  # Configure a remote Solr instance when SOLR_BASE_URL is set (empty by default, meaning the embedded Solr is
+  # used). SOLR_BASE_URL holds the full Solr base URL, so it can carry the scheme (e.g. https), a custom path and
+  # the port.
+  if [ -n "$SOLR_BASE_URL" ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
     # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
     # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
     # deprecated and only configures the search core, which breaks the other cores.
-    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
+    xwiki_set_properties 'solr.remote.baseURL' "$SOLR_BASE_URL"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/18/mariadb-tomcat/xwiki/docker-entrypoint.sh
+++ b/18/mariadb-tomcat/xwiki/docker-entrypoint.sh
@@ -156,7 +156,10 @@ function configure() {
   if [ $INDEX_HOST != 'localhost' ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
-    xwiki_set_properties 'solr.remote.url' "http://$INDEX_HOST:$INDEX_PORT/solr/xwiki"
+    # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
+    # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
+    # deprecated and only configures the search core, which breaks the other cores.
+    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/18/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/18/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -124,8 +124,7 @@ function configure() {
   file_env 'DB_PASSWORD' 'xwiki'
   file_env 'DB_HOST' 'db'
   file_env 'DB_DATABASE' 'xwiki'
-  file_env 'INDEX_HOST' 'localhost'
-  file_env 'INDEX_PORT' '8983'
+  file_env 'SOLR_BASE_URL' ''
   file_env 'JDBC_PARAMS' '?useSSL=false&amp;connectionTimeZone=LOCAL&amp;allowPublicKeyRetrieval=true'
 
   echo "  Deploying XWiki in the '$CONTEXT_PATH' context"
@@ -153,13 +152,16 @@ function configure() {
   echo '  Configure libreoffice...'
   xwiki_set_properties 'openoffice.autoStart' 'true'
 
-  if [ $INDEX_HOST != 'localhost' ]; then
+  # Configure a remote Solr instance when SOLR_BASE_URL is set (empty by default, meaning the embedded Solr is
+  # used). SOLR_BASE_URL holds the full Solr base URL, so it can carry the scheme (e.g. https), a custom path and
+  # the port.
+  if [ -n "$SOLR_BASE_URL" ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
     # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
     # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
     # deprecated and only configures the search core, which breaks the other cores.
-    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
+    xwiki_set_properties 'solr.remote.baseURL' "$SOLR_BASE_URL"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/18/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/18/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -156,7 +156,10 @@ function configure() {
   if [ $INDEX_HOST != 'localhost' ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
-    xwiki_set_properties 'solr.remote.url' "http://$INDEX_HOST:$INDEX_PORT/solr/xwiki"
+    # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
+    # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
+    # deprecated and only configures the search core, which breaks the other cores.
+    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/18/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/18/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -124,8 +124,7 @@ function configure() {
   file_env 'DB_PASSWORD' 'xwiki'
   file_env 'DB_HOST' 'db'
   file_env 'DB_DATABASE' 'xwiki'
-  file_env 'INDEX_HOST' 'localhost'
-  file_env 'INDEX_PORT' '8983'
+  file_env 'SOLR_BASE_URL' ''
   file_env 'JDBC_PARAMS' '?'
 
   echo "  Deploying XWiki in the '$CONTEXT_PATH' context"
@@ -150,13 +149,16 @@ function configure() {
   echo '  Configure libreoffice...'
   xwiki_set_properties 'openoffice.autoStart' 'true'
 
-  if [ $INDEX_HOST != 'localhost' ]; then
+  # Configure a remote Solr instance when SOLR_BASE_URL is set (empty by default, meaning the embedded Solr is
+  # used). SOLR_BASE_URL holds the full Solr base URL, so it can carry the scheme (e.g. https), a custom path and
+  # the port.
+  if [ -n "$SOLR_BASE_URL" ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
     # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
     # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
     # deprecated and only configures the search core, which breaks the other cores.
-    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
+    xwiki_set_properties 'solr.remote.baseURL' "$SOLR_BASE_URL"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/18/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/18/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -153,7 +153,10 @@ function configure() {
   if [ $INDEX_HOST != 'localhost' ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
-    xwiki_set_properties 'solr.remote.url' "http://$INDEX_HOST:$INDEX_PORT/solr/xwiki"
+    # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
+    # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
+    # deprecated and only configures the search core, which breaks the other cores.
+    xwiki_set_properties 'solr.remote.baseURL' "http://$INDEX_HOST:$INDEX_PORT/solr"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/README.md
+++ b/README.md
@@ -533,18 +533,38 @@ solr.remote.baseURL=http://$INDEX_HOST:$INDEX_PORT/solr
 
 #### Preparing Solr container
 
-The simplest way to create an external Solr service is using the [official Solr image](https://hub.docker.com/_/solr/).
+Since XWiki 12.2 a remote Solr instance needs **several cores** (`search`, `events`, `ratings` and
+`extension_index`), and XWiki does not create them itself because the Solr REST API is too limited. They must be
+created on the Solr server before starting XWiki. The `solr-init.sh` script (from the
+[docker-xwiki repository](https://github.com/xwiki-contrib/docker-xwiki/tree/master/contrib/solr)) does that for you.
 
--	Select the appropriate XWiki Solr configuration JAR from [here](https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-search-solr-server-data/) (Note: it's usually better to synchronize it with your version of XWiki)
--	Place this JAR in a directory along side `solr-init.sh` that you can fetch from the [docker-xwiki repository](https://github.com/xwiki-contrib/docker-xwiki/tree/master/contrib/solr)
+The Solr image is built from the [official Solr image](https://hub.docker.com/_/solr/) with two additions (see the
+`Dockerfile` next to `solr-init.sh`): the `unzip` tool (needed by `solr-init.sh`) and Solr's `analysis-extras` module
+(the XWiki search core relies on language analyzers, such as the Polish stemmer, shipped in that module).
+
+-	Download the two XWiki Solr configuration ZIPs synchronized with your version of XWiki and place them in a
+	directory alongside `solr-init.sh` and its `Dockerfile`:
+	-	the search core config: [xwiki-platform-search-solr-server-core-search](https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-search-solr-server-core-search/)
+	-	the minimal core config (used for the `events`, `ratings` and `extension_index` cores): [xwiki-platform-search-solr-server-core-minimal](https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-search-solr-server-core-minimal/)
 -	Ensure that this directory is owned by the Solr user and group `chown -R 8983:8983 /path/to/solr/init/directory`
--	Launch the Solr container and mount this directory at `/docker-entrypoint-initdb.d`
--	This will execute `solr-init.sh` on container startup and prepare the XWiki core with the contents from the given JAR
--	If you want to persist the Solr index outside of the container with a bind mount, make sure that that directory is owned by the Solr user and group `chown 8983:8983 /my/path/solr`
+-	Launch the Solr container built from that `Dockerfile` and mount this directory at `/docker-entrypoint-initdb.d`
+-	This will execute `solr-init.sh` on container startup and create the XWiki cores from the two ZIPs
+-	If you want to persist the Solr index outside of the container with a bind mount (mounted at `/var/solr`), make
+	sure that that directory is owned by the Solr user and group `chown 8983:8983 /my/path/solr`
+
+> Note: the cores are named `<prefix>_<core>_<solrMajorVersion>` (e.g. `xwiki_search_9`). The prefix defaults to
+> `xwiki` (the `solr.remote.corePrefix` property); override it by passing `-e XWIKI_SOLR_CORE_PREFIX=...` to the Solr
+> container if you changed that property. The Solr major version must match the Solr image you use.
 
 #### Example with `docker run`
 
 Start your chosen database container normally using the docker run command above, this example happens to assume MySQL was chosen.
+
+First build the Solr image from the `Dockerfile` located next to `solr-init.sh`:
+
+```console
+docker build -t xwiki-solr /path/to/solr/init/directory
+```
 
 The command below will configure the Solr container to initialize based on the contents of `/path/to/solr/init/directory/` and save its data on the host in a `/my/path/solr` directory:
 
@@ -553,8 +573,8 @@ docker run \
   --net=xwiki-nw \
   --name solr-xwiki \
   -v /path/to/solr/init/directory:/docker-entrypoint-initdb.d \
-  -v /my/path/solr:/var/solr/data/xwiki \
-  -d solr:9
+  -v /my/path/solr:/var/solr \
+  -d xwiki-solr
 ```
 
 Then start the XWiki container, the below command is nearly identical to that specified in the Starting XWiki section above, except that it includes the `-e INDEX_HOST=` environment variable which specifies the hostname of the Solr container.
@@ -575,7 +595,7 @@ docker run \
 
 #### Example with `docker compose`
 
-The below compose file assumes that `./solr` contains `solr-init.sh` and the configuration JAR file.
+The below compose file assumes that `./solr` contains `solr-init.sh`, its `Dockerfile` and the two configuration ZIP files.
 
 ```yaml
 version: '2'
@@ -619,7 +639,7 @@ services:
     networks:
       - bridge
   index:
-    image: "solr:9"
+    build: ./solr
     container_name: xwiki-index
     volumes:
       - ./solr:/docker-entrypoint-initdb.d

--- a/README.md
+++ b/README.md
@@ -532,45 +532,42 @@ solr.remote.baseURL=$SOLR_BASE_URL
 #### Preparing Solr container
 
 Since XWiki 12.2 a remote Solr instance needs **several cores** (`search`, `events`, `ratings` and
-`extension_index`), and XWiki does not create them itself because the Solr REST API is too limited. They must be
-created on the Solr server before starting XWiki. The `solr-init.sh` script (from the
-[docker-xwiki repository](https://github.com/xwiki-contrib/docker-xwiki/tree/master/contrib/solr)) does that for you.
+`extension_index`), and XWiki does not create them itself because the Solr REST API is too limited. They must exist
+on the Solr server before starting XWiki.
 
-The Solr image is built from the [official Solr image](https://hub.docker.com/_/solr/) with two additions (see the
-`Dockerfile` next to `solr-init.sh`): the `unzip` tool (needed by `solr-init.sh`) and Solr's `analysis-extras` module
-(the XWiki search core relies on language analyzers, such as the Polish stemmer, shipped in that module).
+The Solr image is built (see the `Dockerfile` next to `solr-init.sh`, both in the
+[docker-xwiki repository](https://github.com/xwiki-contrib/docker-xwiki/tree/master/contrib/solr)) from the
+[official Solr image](https://hub.docker.com/_/solr/). At build time it downloads XWiki's pre-built Solr core
+packages (one per core, matching your XWiki version) and, on container startup, `solr-init.sh` lays them into the
+Solr home. It also enables Solr's `analysis-extras` module, which the XWiki search core needs (its schema relies on
+language analyzers, such as the Polish stemmer, shipped in that module).
 
--	Download the two XWiki Solr configuration ZIPs synchronized with your version of XWiki and place them in a
-	directory alongside `solr-init.sh` and its `Dockerfile`:
-	-	the search core config: [xwiki-platform-search-solr-server-core-search](https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-search-solr-server-core-search/)
-	-	the minimal core config (used for the `events`, `ratings` and `extension_index` cores): [xwiki-platform-search-solr-server-core-minimal](https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-search-solr-server-core-minimal/)
--	Ensure that this directory is owned by the Solr user and group `chown -R 8983:8983 /path/to/solr/init/directory`
--	Launch the Solr container built from that `Dockerfile` and mount this directory at `/docker-entrypoint-initdb.d`
--	This will execute `solr-init.sh` on container startup and create the XWiki cores from the two ZIPs
+-	Build the image, passing your XWiki version so the matching cores are downloaded (see the examples below). There
+	is no extra file to download and no init directory to mount.
 -	If you want to persist the Solr index outside of the container with a bind mount (mounted at `/var/solr`), make
-	sure that that directory is owned by the Solr user and group `chown 8983:8983 /my/path/solr`
+	sure that directory is owned by the Solr user and group `chown 8983:8983 /my/path/solr`
 
-> Note: the cores are named `<prefix>_<core>_<solrMajorVersion>` (e.g. `xwiki_search_9`). The prefix defaults to
-> `xwiki` (the `solr.remote.corePrefix` property); override it by passing `-e XWIKI_SOLR_CORE_PREFIX=...` to the Solr
-> container if you changed that property. The Solr major version must match the Solr image you use.
+> Note: the cores are named `xwiki_<core>_<solrMajorVersion>` (e.g. `xwiki_search_9`). The `xwiki` prefix matches the
+> default `solr.remote.corePrefix` property; if you changed that property, adjust the core directory names
+> accordingly. The Solr major version must match the Solr image you use (the provided `Dockerfile` uses `solr:9`).
 
 #### Example with `docker run`
 
 Start your chosen database container normally using the docker run command above, this example happens to assume MySQL was chosen.
 
-First build the Solr image from the `Dockerfile` located next to `solr-init.sh`:
+First build the Solr image from the `contrib/solr` directory (which contains the `Dockerfile` and `solr-init.sh`),
+passing the XWiki version you run so the matching cores are downloaded:
 
 ```console
-docker build -t xwiki-solr /path/to/solr/init/directory
+docker build -t xwiki-solr --build-arg XWIKI_VERSION=18.5.0 /path/to/contrib/solr
 ```
 
-The command below will configure the Solr container to initialize based on the contents of `/path/to/solr/init/directory/` and save its data on the host in a `/my/path/solr` directory:
+The command below runs the Solr container and persists its data on the host in a `/my/path/solr` directory (the cores are created automatically on the first start):
 
 ```console
 docker run \
   --net=xwiki-nw \
   --name solr-xwiki \
-  -v /path/to/solr/init/directory:/docker-entrypoint-initdb.d \
   -v /my/path/solr:/var/solr \
   -d xwiki-solr
 ```
@@ -593,7 +590,9 @@ docker run \
 
 #### Example with `docker compose`
 
-The below compose file assumes that `./solr` contains `solr-init.sh`, its `Dockerfile` and the two configuration ZIP files.
+The below compose file assumes that `./solr` contains the `Dockerfile` and `solr-init.sh` (the `contrib/solr`
+directory of this repository). The `XWIKI_VERSION` build argument selects the Solr cores to download, so keep it in
+sync with the XWiki version used by the `web` service.
 
 ```yaml
 version: '2'
@@ -637,10 +636,12 @@ services:
     networks:
       - bridge
   index:
-    build: ./solr
+    build:
+      context: ./solr
+      args:
+        XWIKI_VERSION: 18.5.0
     container_name: xwiki-index
     volumes:
-      - ./solr:/docker-entrypoint-initdb.d
       - solr-data:/var/solr
     networks:
       - bridge

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ The first time you create a container out of the xwiki image, a shell script (`/
 -	`DB_PASSWORD`: The user password used by XWiki to read/write to the DB.
 -	`DB_DATABASE`: The name of the XWiki database to use/create.
 -	`DB_HOST`: The name of the host (or docker container) containing the database. Default is "db".
--	`SOLR_BASE_URL`: The base URL of an externally configured Solr instance (for example `https://solr.example.com/solr`). When left empty (the default), XWiki uses its embedded Solr instance. The value is the Solr base URL, not a single core: it can carry the scheme (`http`/`https`), a custom path and the port.
+-	`SOLR_BASE_URL`: The base URL of an externally configured Solr instance (for example `https://solr.example.com/solr`). When left empty (the default), XWiki uses its embedded Solr instance.
 -   `CONTEXT_PATH`: The name of the context path under which XWiki will be deployed in Tomcat. If not specified then it'll be deployed as ROOT.
     -   If you had set this environment property and later on, recreate the XWiki container without passing it (i.e you wish to deploy XWiki as ROOT again), the you'll need to edit the `xwiki.cfg` file in your mapped local permanent directory and set `xwiki.webapppath=`.
 -	`JDBC_PARAMS`: Custom JDB parameters to pass to the JBC connection. Setting this value overwrites the default parameters used (which depend on the DB used). The value must start with a question mark and the content be XML-encoded. For example: `?useSSL=false&amp;connectionTimeZone=LOCAL&amp;allowPublicKeyRetrieval=true`.
@@ -531,7 +531,7 @@ solr.remote.baseURL=$SOLR_BASE_URL
 
 #### Preparing Solr container
 
-Since XWiki 12.2 a remote Solr instance needs **several cores** (`search`, `events`, `ratings` and
+A remote Solr instance needs **several cores** (`search`, `events`, `ratings` and
 `extension_index`), and XWiki does not create them itself because the Solr REST API is too limited. They must exist
 on the Solr server before starting XWiki.
 

--- a/README.md
+++ b/README.md
@@ -374,8 +374,7 @@ The first time you create a container out of the xwiki image, a shell script (`/
 -	`DB_PASSWORD`: The user password used by XWiki to read/write to the DB.
 -	`DB_DATABASE`: The name of the XWiki database to use/create.
 -	`DB_HOST`: The name of the host (or docker container) containing the database. Default is "db".
--	`INDEX_HOST`: The hostname of an externally configured Solr instance. Defaults to "localhost", and configures an embedded Solr instance.
--	`INDEX_PORT`: The port used by an externally configured Solr instance. Defaults to 8983.
+-	`SOLR_BASE_URL`: The base URL of an externally configured Solr instance (for example `https://solr.example.com/solr`). When left empty (the default), XWiki uses its embedded Solr instance. The value is the Solr base URL, not a single core: it can carry the scheme (`http`/`https`), a custom path and the port.
 -   `CONTEXT_PATH`: The name of the context path under which XWiki will be deployed in Tomcat. If not specified then it'll be deployed as ROOT.
     -   If you had set this environment property and later on, recreate the XWiki container without passing it (i.e you wish to deploy XWiki as ROOT again), the you'll need to edit the `xwiki.cfg` file in your mapped local permanent directory and set `xwiki.webapppath=`.
 -	`JDBC_PARAMS`: Custom JDB parameters to pass to the JBC connection. Setting this value overwrites the default parameters used (which depend on the DB used). The value must start with a question mark and the content be XML-encoded. For example: `?useSSL=false&amp;connectionTimeZone=LOCAL&amp;allowPublicKeyRetrieval=true`.
@@ -386,8 +385,7 @@ In order to support [Docker secrets](https://docs.docker.com/engine/swarm/secret
 -	`DB_PASSWORD_FILE`: The location, inside the container, of a file containing the value for `DB_PASSWORD`
 -	`DB_DATABASE_FILE`: The location, inside the container, of a file containing the value for `DB_DATABASE`
 -	`DB_HOST_FILE`: The location, inside the container, of a file containing the value for `DB_HOST`
--	`INDEX_HOST_FILE`: The location, inside the container, of a file containing the value for `INDEX_HOST`
--	`INDEX_PORT_FILE`: The location, inside the container, of a file containing the value for `INDEX_PORT`
+-	`SOLR_BASE_URL_FILE`: The location, inside the container, of a file containing the value for `SOLR_BASE_URL`
 -	`JDBC_PARAMS_FILE`: The location, inside the container, of a file containing the value for `JDBC_PARAMS`
 
 *Note:* For each configuration value, the normal environment variable and \_FILE environment variable are mutually exclusive. Providing values for both variables will result in an error.
@@ -524,11 +522,11 @@ From the [XWiki Solr Search API documentation](https://extensions.xwiki.org/xwik
 >
 > You can also find more Solr-specific performance details on https://wiki.apache.org/solr/SolrPerformanceProblems. Standalone Solr also comes with a very nice UI, along with monitoring and test tools.
 
-This image provides the configuration parameters `INDEX_HOST` and `INDEX_PORT` which are used to configure `xwiki.properties` with:
+This image provides the `SOLR_BASE_URL` configuration parameter which is used to configure `xwiki.properties` with:
 
 ```data
 solr.type=remote
-solr.remote.baseURL=http://$INDEX_HOST:$INDEX_PORT/solr
+solr.remote.baseURL=$SOLR_BASE_URL
 ```
 
 #### Preparing Solr container
@@ -577,7 +575,7 @@ docker run \
   -d xwiki-solr
 ```
 
-Then start the XWiki container, the below command is nearly identical to that specified in the Starting XWiki section above, except that it includes the `-e INDEX_HOST=` environment variable which specifies the hostname of the Solr container.
+Then start the XWiki container, the below command is nearly identical to that specified in the Starting XWiki section above, except that it includes the `-e SOLR_BASE_URL=` environment variable which specifies the base URL of the Solr container.
 
 ```console
 docker run \
@@ -589,7 +587,7 @@ docker run \
   -e DB_PASSWORD=xwiki \
   -e DB_DATABASE=xwiki \
   -e DB_HOST=mysql-xwiki \
-  -e INDEX_HOST=solr-xwiki \
+  -e SOLR_BASE_URL=http://solr-xwiki:8983/solr \
   -d xwiki:stable-mysql-tomcat
 ```
 
@@ -617,7 +615,7 @@ services:
       - DB_PASSWORD=xwiki
       - DB_DATABASE=xwiki
       - DB_HOST=xwiki-db
-      - INDEX_HOST=xwiki-index
+      - SOLR_BASE_URL=http://xwiki-index:8983/solr
     volumes:
       - xwiki-data:/usr/local/xwiki
     networks:

--- a/contrib/solr/Dockerfile
+++ b/contrib/solr/Dockerfile
@@ -19,8 +19,7 @@
 # ---------------------------------------------------------------------------
 
 # Adjust the Solr major version to match your XWiki version (XWiki supports the current and previous Solr major
-# versions). It must stay consistent with the "_<solrMajorVersion>" suffix baked into the core packages downloaded
-# below (the packages targeting Solr 9 lay their cores under ".../xwiki_<core>_9").
+# versions), keeping it consistent with the core packages downloaded below.
 FROM solr:9
 
 # The XWiki version whose Solr cores to install. It must match the version of XWiki you run. Override at build time
@@ -29,10 +28,8 @@ ARG XWIKI_VERSION=18.5.0
 
 USER root
 
-# Download the pre-built XWiki Solr core packages so that "solr-init.sh" can lay them into the Solr home on startup.
-# XWiki publishes one Debian package per core (search, events, ratings, extension_index); each unpacks to
-# "/var/solr/data/xwiki_<core>_9" with its "core.properties", full "conf/" and the required "lib/" jars, which is
-# exactly what Solr's core discovery expects. Reusing these packages avoids reproducing the core layout by hand.
+# Download the pre-built XWiki Solr core packages (one Debian package per core: search, events, ratings,
+# extension_index) so that "solr-init.sh" can lay them into the Solr home on startup.
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends ca-certificates curl && \
     mkdir -p /opt/xwiki-solr && \

--- a/contrib/solr/Dockerfile
+++ b/contrib/solr/Dockerfile
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------
+# See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+# ---------------------------------------------------------------------------
+
+# The official Solr image doesn't ship "unzip", which "solr-init.sh" needs to extract the XWiki Solr configuration
+# ZIPs into the Solr cores. This image simply adds it. Adjust the Solr major version to match your XWiki version
+# (XWiki supports the current and previous Solr major versions).
+FROM solr:9
+
+USER root
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends unzip && \
+    rm -rf /var/lib/apt/lists/*
+USER solr
+
+# XWiki's search core schema relies on language analyzers (e.g. the Polish "stempelPolishStem" filter) shipped in
+# Solr's optional "analysis-extras" module. Without it the search core fails to load with an SPI class error.
+ENV SOLR_MODULES=analysis-extras

--- a/contrib/solr/Dockerfile
+++ b/contrib/solr/Dockerfile
@@ -18,17 +18,40 @@
 # 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 # ---------------------------------------------------------------------------
 
-# The official Solr image doesn't ship "unzip", which "solr-init.sh" needs to extract the XWiki Solr configuration
-# ZIPs into the Solr cores. This image simply adds it. Adjust the Solr major version to match your XWiki version
-# (XWiki supports the current and previous Solr major versions).
+# Adjust the Solr major version to match your XWiki version (XWiki supports the current and previous Solr major
+# versions). It must stay consistent with the "_<solrMajorVersion>" suffix baked into the core packages downloaded
+# below (the packages targeting Solr 9 lay their cores under ".../xwiki_<core>_9").
 FROM solr:9
 
+# The XWiki version whose Solr cores to install. It must match the version of XWiki you run. Override at build time
+# with "--build-arg XWIKI_VERSION=<version>".
+ARG XWIKI_VERSION=18.5.0
+
 USER root
+
+# Download the pre-built XWiki Solr core packages so that "solr-init.sh" can lay them into the Solr home on startup.
+# XWiki publishes one Debian package per core (search, events, ratings, extension_index); each unpacks to
+# "/var/solr/data/xwiki_<core>_9" with its "core.properties", full "conf/" and the required "lib/" jars, which is
+# exactly what Solr's core discovery expects. Reusing these packages avoids reproducing the core layout by hand.
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends unzip && \
+    apt-get install --yes --no-install-recommends ca-certificates curl && \
+    mkdir -p /opt/xwiki-solr && \
+    base='https://nexus.xwiki.org/nexus/content/groups/public/org/xwiki/platform' && \
+    for core in search events ratings extension_index; do \
+        artifact="xwiki-platform-distribution-debian-solr-core-${core}"; \
+        curl -fSL -o "/opt/xwiki-solr/${artifact}.deb" \
+            "${base}/${artifact}/${XWIKI_VERSION}/${artifact}-${XWIKI_VERSION}.deb"; \
+    done && \
     rm -rf /var/lib/apt/lists/*
+
+# Run the core initialization on container startup (Solr executes the scripts in /docker-entrypoint-initdb.d/ before
+# starting). Baking it in (rather than bind-mounting it) means running the image needs no init directory mount.
+COPY solr-init.sh /docker-entrypoint-initdb.d/solr-init.sh
+RUN chmod +x /docker-entrypoint-initdb.d/solr-init.sh
+
 USER solr
 
 # XWiki's search core schema relies on language analyzers (e.g. the Polish "stempelPolishStem" filter) shipped in
-# Solr's optional "analysis-extras" module. Without it the search core fails to load with an SPI class error.
+# Solr's optional "analysis-extras" module (the core packages do not, and cannot, bundle it). Without it the search
+# core fails to load with an SPI class error.
 ENV SOLR_MODULES=analysis-extras

--- a/contrib/solr/solr-init.sh
+++ b/contrib/solr/solr-init.sh
@@ -19,12 +19,9 @@
 # 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 # ---------------------------------------------------------------------------
 
-# Initializes the Solr cores required by XWiki when using a remote (standalone) Solr instance.
-#
-# Since XWiki 12.2 a remote Solr instance needs several cores (XWiki does not create them itself because the Solr
-# REST API is too limited). This script lays them into the Solr home from the pre-built XWiki Solr core packages
-# baked into the image under /opt/xwiki-solr (see the Dockerfile). Each package unpacks to
-# "/var/solr/data/xwiki_<core>_9" with its "core.properties", "conf/" and "lib/", so Solr discovers the cores.
+# Initializes the Solr cores required by XWiki when using a remote (standalone) Solr instance. It reuses the
+# standard XWiki Solr core packages (baked into the image under /opt/xwiki-solr, see the Dockerfile), which are
+# designed to work with a standard Solr install.
 #
 # Usage:
 # - Build the Solr image from the Dockerfile next to this script (it downloads the core packages and copies this

--- a/contrib/solr/solr-init.sh
+++ b/contrib/solr/solr-init.sh
@@ -22,67 +22,37 @@
 # Initializes the Solr cores required by XWiki when using a remote (standalone) Solr instance.
 #
 # Since XWiki 12.2 a remote Solr instance needs several cores (XWiki does not create them itself because the Solr
-# REST API is too limited). This script pre-creates them from the two XWiki Solr configuration ZIPs.
+# REST API is too limited). This script lays them into the Solr home from the pre-built XWiki Solr core packages
+# baked into the image under /opt/xwiki-solr (see the Dockerfile). Each package unpacks to
+# "/var/solr/data/xwiki_<core>_9" with its "core.properties", "conf/" and "lib/", so Solr discovers the cores.
 #
 # Usage:
-# - Download the two configuration ZIPs matching your XWiki version and place them next to this script:
-#     - the search core config:  xwiki-platform-search-solr-server-core-search-<version>.zip
-#     - the minimal core config: xwiki-platform-search-solr-server-core-minimal-<version>.zip
-#   Both are published under https://maven.xwiki.org/releases/org/xwiki/platform/ (one directory per artifact).
-# - Ensure that this directory, and its contents, are owned by the solr user and group, 8983:8983
-#     - ex. chown -R 8983:8983 $PARENT_DIRECTORY
-# - Mount the parent directory of this script to /docker-entrypoint-initdb.d/ when you run the Solr container
-#     - ex. add the following to the docker run command ... -v $PWD/$PARENT_DIRECTORY:/docker-entrypoint-initdb.d ...
-# - At run time, before starting Solr, the container will execute scripts in the /docker-entrypoint-initdb.d/ directory.
+# - Build the Solr image from the Dockerfile next to this script (it downloads the core packages and copies this
+#   script into /docker-entrypoint-initdb.d). Pass "--build-arg XWIKI_VERSION=<version>" to match your XWiki version.
+# - Run that image: on startup, before Solr starts, the container executes scripts in /docker-entrypoint-initdb.d/,
+#   so this script runs and creates any missing core in the (possibly mounted) Solr home.
 
 set -e
 
-initdir='/docker-entrypoint-initdb.d'
+debdir='/opt/xwiki-solr'
 datadir='/var/solr/data'
-# XWiki prefixes its Solr cores to avoid collisions. It matches the "solr.remote.corePrefix" xwiki.properties
-# property (default "xwiki"). Override with XWIKI_SOLR_CORE_PREFIX if you changed that property.
-prefix="${XWIKI_SOLR_CORE_PREFIX:-xwiki}"
 
-cd "$initdir"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
 
-# XWiki names its cores "<prefix>_<core>_<solrMajorVersion>" (e.g. xwiki_search_9), so we need the Solr major version.
-solrVersion=$(solr version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)
-major="${solrVersion%%.*}"
-if [ -z "$major" ]; then
-	echo 'Unable to determine the Solr major version'
-	exit 1
-fi
-
-# Locate the two configuration ZIPs (the search core uses the full config, the other cores use the minimal one).
-searchZip=$(find . -maxdepth 1 -type f -name '*server-core-search*.zip' | head -1)
-minimalZip=$(find . -maxdepth 1 -type f -name '*server-core-minimal*.zip' | head -1)
-if [ -z "$searchZip" ]; then
-	echo 'No XWiki Solr search core configuration ZIP found (*server-core-search*.zip)'
-	exit 1
-fi
-if [ -z "$minimalZip" ]; then
-	echo 'No XWiki Solr minimal core configuration ZIP found (*server-core-minimal*.zip)'
-	exit 1
-fi
-
-# Creates a Solr core by unzipping a configuration ZIP into its data directory. The ZIPs ship an empty
-# "core.properties" file, which makes Solr use the directory name as the core name (core discovery).
-# $1 - the XWiki core name (e.g. search, events)
-# $2 - the configuration ZIP to unzip
-create_core() {
-	local core="$1"
-	local zip="$2"
-	local dir="$datadir/${prefix}_${core}_${major}"
-	if [ -d "$dir" ]; then
-		echo "Solr core [$(basename "$dir")] already exists, skipping"
-		return
-	fi
-	echo "Creating Solr core [$(basename "$dir")]"
-	mkdir -p "$dir"
-	unzip -o -q "$zip" -d "$dir"
-}
-
-create_core 'search' "$searchZip"
-create_core 'extension_index' "$minimalZip"
-create_core 'ratings' "$minimalZip"
-create_core 'events' "$minimalZip"
+for deb in "$debdir"/*.deb; do
+	# "dpkg -x" unpacks the package payload without registering it (there is no dpkg database in the Solr image).
+	# We stage it, then copy only the missing cores so re-runs (the init scripts run on every start) don't clobber
+	# an already-populated core in a persisted volume.
+	dpkg -x "$deb" "$tmp"
+	for core in "$tmp"/var/solr/data/*/; do
+		name="$(basename "$core")"
+		if [ -d "$datadir/$name" ]; then
+			echo "Solr core [$name] already exists, skipping"
+		else
+			echo "Creating Solr core [$name]"
+			cp -a "$core" "$datadir/$name"
+		fi
+	done
+	rm -rf "$tmp/var"
+done

--- a/contrib/solr/solr-init.sh
+++ b/contrib/solr/solr-init.sh
@@ -1,39 +1,88 @@
 #!/bin/bash
+# ---------------------------------------------------------------------------
+# See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+# ---------------------------------------------------------------------------
 
+# Initializes the Solr cores required by XWiki when using a remote (standalone) Solr instance.
+#
+# Since XWiki 12.2 a remote Solr instance needs several cores (XWiki does not create them itself because the Solr
+# REST API is too limited). This script pre-creates them from the two XWiki Solr configuration ZIPs.
+#
 # Usage:
-# - Place the XWiki Solr configuration jar into the same directory as this script
-#	- ex. wget https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-search-solr-server-data/10.1/xwiki-platform-search-solr-server-data-10.1.jar
-# - ensure that this directory, and it's contents, are owned by the solr user and group, 8983:8983
-#	- ex. chown -R 8983:8983 $PARENT_DIRECTORY
-# - mount the partent directory of this script to /docker-entrypoint-initdb.d/ when you run the Solr container
-#	- ex. add the following to docker run command ... -v $PWD/$PARENT_DIRECTORY:/docker-entrypoint-initdb.d ...
+# - Download the two configuration ZIPs matching your XWiki version and place them next to this script:
+#     - the search core config:  xwiki-platform-search-solr-server-core-search-<version>.zip
+#     - the minimal core config: xwiki-platform-search-solr-server-core-minimal-<version>.zip
+#   Both are published under https://maven.xwiki.org/releases/org/xwiki/platform/ (one directory per artifact).
+# - Ensure that this directory, and its contents, are owned by the solr user and group, 8983:8983
+#     - ex. chown -R 8983:8983 $PARENT_DIRECTORY
+# - Mount the parent directory of this script to /docker-entrypoint-initdb.d/ when you run the Solr container
+#     - ex. add the following to the docker run command ... -v $PWD/$PARENT_DIRECTORY:/docker-entrypoint-initdb.d ...
 # - At run time, before starting Solr, the container will execute scripts in the /docker-entrypoint-initdb.d/ directory.
 
-cd /docker-entrypoint-initdb.d/
-location='/var/solr/data/'
+set -e
 
-# Verify the existence of a singular XWiki Solr configuration jar
-jars=$(find . -type f -name *.jar | wc -l)
-if [ $jars -lt 1 ]; then
-	echo 'No XWiki Solr configuration jar found'
-	exit 1
-elif [ $jars -gt 1 ]; then
-	echo 'Too many XWiki Solr configuration jars found, please include only one jar'
+initdir='/docker-entrypoint-initdb.d'
+datadir='/var/solr/data'
+# XWiki prefixes its Solr cores to avoid collisions. It matches the "solr.remote.corePrefix" xwiki.properties
+# property (default "xwiki"). Override with XWIKI_SOLR_CORE_PREFIX if you changed that property.
+prefix="${XWIKI_SOLR_CORE_PREFIX:-xwiki}"
+
+cd "$initdir"
+
+# XWiki names its cores "<prefix>_<core>_<solrMajorVersion>" (e.g. xwiki_search_9), so we need the Solr major version.
+solrVersion=$(solr version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)
+major="${solrVersion%%.*}"
+if [ -z "$major" ]; then
+	echo 'Unable to determine the Solr major version'
 	exit 1
 fi
-# Get the name of the XWiki Solr configuration jar
-jar=$(find . -type f -name *.jar)
-# Ensure that the Solr directory exists
-mkdir -p $location
 
-# Add the XWiki Solr plugin
-plugin=$(unzip -Z1 $jar | grep lib.*jar)
-unzip -o $jar \
-	$plugin \
-	-d $location
+# Locate the two configuration ZIPs (the search core uses the full config, the other cores use the minimal one).
+searchZip=$(find . -maxdepth 1 -type f -name '*server-core-search*.zip' | head -1)
+minimalZip=$(find . -maxdepth 1 -type f -name '*server-core-minimal*.zip' | head -1)
+if [ -z "$searchZip" ]; then
+	echo 'No XWiki Solr search core configuration ZIP found (*server-core-search*.zip)'
+	exit 1
+fi
+if [ -z "$minimalZip" ]; then
+	echo 'No XWiki Solr minimal core configuration ZIP found (*server-core-minimal*.zip)'
+	exit 1
+fi
 
-# Add the XWiki core
-core='xwiki/*'
-unzip -o $jar \
-	$core \
-	-d $location
+# Creates a Solr core by unzipping a configuration ZIP into its data directory. The ZIPs ship an empty
+# "core.properties" file, which makes Solr use the directory name as the core name (core discovery).
+# $1 - the XWiki core name (e.g. search, events)
+# $2 - the configuration ZIP to unzip
+create_core() {
+	local core="$1"
+	local zip="$2"
+	local dir="$datadir/${prefix}_${core}_${major}"
+	if [ -d "$dir" ]; then
+		echo "Solr core [$(basename "$dir")] already exists, skipping"
+		return
+	fi
+	echo "Creating Solr core [$(basename "$dir")]"
+	mkdir -p "$dir"
+	unzip -o -q "$zip" -d "$dir"
+}
+
+create_core 'search' "$searchZip"
+create_core 'extension_index' "$minimalZip"
+create_core 'ratings' "$minimalZip"
+create_core 'events' "$minimalZip"

--- a/template/xwiki/docker-entrypoint.sh
+++ b/template/xwiki/docker-entrypoint.sh
@@ -168,7 +168,10 @@ function configure() {
   if [ \$INDEX_HOST != 'localhost' ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
-    xwiki_set_properties 'solr.remote.url' "http://\$INDEX_HOST:\$INDEX_PORT/solr/xwiki"
+    # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
+    # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
+    # deprecated and only configures the search core, which breaks the other cores.
+    xwiki_set_properties 'solr.remote.baseURL' "http://\$INDEX_HOST:\$INDEX_PORT/solr"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.

--- a/template/xwiki/docker-entrypoint.sh
+++ b/template/xwiki/docker-entrypoint.sh
@@ -124,8 +124,7 @@ function configure() {
   file_env 'DB_PASSWORD' 'xwiki'
   file_env 'DB_HOST' 'db'
   file_env 'DB_DATABASE' 'xwiki'
-  file_env 'INDEX_HOST' 'localhost'
-  file_env 'INDEX_PORT' '8983'
+  file_env 'SOLR_BASE_URL' ''
   <% // Set default JDBC param values depending on the DB
   if (db == 'mysql') {
     print '''file_env 'JDBC_PARAMS' '?useSSL=false&amp;connectionTimeZone=LOCAL&amp;allowPublicKeyRetrieval=true''''
@@ -165,13 +164,16 @@ function configure() {
   echo '  Configure libreoffice...'
   xwiki_set_properties 'openoffice.autoStart' 'true'
 
-  if [ \$INDEX_HOST != 'localhost' ]; then
+  # Configure a remote Solr instance when SOLR_BASE_URL is set (empty by default, meaning the embedded Solr is
+  # used). SOLR_BASE_URL holds the full Solr base URL, so it can carry the scheme (e.g. https), a custom path and
+  # the port.
+  if [ -n "\$SOLR_BASE_URL" ]; then
     echo '  Configuring remote Solr Index'
     xwiki_set_properties 'solr.type' 'remote'
     # Point to the Solr base URL (not a single core): XWiki manages several cores (search, events, ratings,
     # extension index) and creates its clients under this base. The old single-core "solr.remote.url" property is
     # deprecated and only configures the search core, which breaks the other cores.
-    xwiki_set_properties 'solr.remote.baseURL' "http://\$INDEX_HOST:\$INDEX_PORT/solr"
+    xwiki_set_properties 'solr.remote.baseURL' "\$SOLR_BASE_URL"
   fi
 
   # If the files already exist then copy them to the XWiki's WEB-INF directory.


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XDOCKER-183

## Description

Since XWiki 12.2 a remote Solr instance uses several cores (`search`, `events`, `ratings`, `extension_index`) and XWiki no longer supports configuring it through a single-core URL. The Docker image was still writing the deprecated single-core `solr.remote.url` property (pointing at `.../solr/xwiki`), which only configures the search core and breaks the others (e.g. the extension index — see the duplicate XWIKI-18550).

- `template/xwiki/docker-entrypoint.sh`: write `solr.remote.baseURL` (the Solr base URL) instead of the deprecated `solr.remote.url`. Remote Solr is now configured through a single `SOLR_BASE_URL` environment variable (empty by default, meaning the embedded Solr is used). Because it holds the full base URL, it can carry the scheme (e.g. `https`), a custom path and the port. The previous `INDEX_HOST`/`INDEX_PORT` variables are removed (see Clarifications).
- `contrib/solr/solr-init.sh`: rewritten to create the four required cores from the two current XWiki Solr configuration ZIPs (`server-core-search` + `server-core-minimal`). The old single-core `server-data` JAR it used was discontinued after 9.x. The script is idempotent and derives the Solr major version and core prefix.
- `contrib/solr/Dockerfile`: new. The official Solr image lacks `unzip` (needed by `solr-init.sh`, and as a non-root user it cannot `apt-get`) and the `analysis-extras` module (the search core schema uses language analyzers such as the Polish `stempelPolishStem` filter, otherwise the search core fails to load). This small image adds both.
- `README.md`: updated the "Using an external Solr service" section (two ZIPs instead of the discontinued JAR, four cores, the custom Solr image, and the `SOLR_BASE_URL` variable).

## Clarifications

Supersedes #31, which renamed the env vars (`INDEX_BASEURL`/`INDEX_TYPE`) and whose default base URL still kept the `/solr/xwiki` core suffix — so it would not actually fix the multi-core issue.

This PR fixes the real multi-core bug (`solr.remote.baseURL` pointing at the Solr base, not a single core) and, at the same time, replaces `INDEX_HOST`/`INDEX_PORT` with a single `SOLR_BASE_URL`. Dropping `INDEX_HOST`/`INDEX_PORT` rather than keeping them as a deprecated fallback was [agreed on the PR](https://github.com/xwiki/xwiki-docker/pull/90#issuecomment-5035368334): they could only ever build an `http://host:port/solr` URL (no `https`, no custom path), and they were broken anyway since the multi-core change, so very few configurations rely on them. The migration is covered in the proposed release note below.

## Executed Tests

Validated end-to-end against a live `solr:9.10.1` container built from the new `contrib/solr/Dockerfile`, using the real 18.5.0 configuration ZIPs:
- `solr-init.sh` creates all four cores (`xwiki_search_9`, `xwiki_extension_index_9`, `xwiki_ratings_9`, `xwiki_events_9`).
- All four cores load and are queryable (HTTP 200) and are reported by the CoreAdmin STATUS API (the same call XWiki's `RemoteSolr.getCores()` uses to locate cores).
- Idempotent on container restart ("already exists, skipping").
- `./gradlew` regenerates all version/variant directories from the template (committed together), and the generated entrypoints pass `bash -n`.

## Expected merging strategy

Prefers squash: Yes
