### PR TITLE
XDOCKER-53: LibreOffice creates zombie processes

### DIFF
--- a/16/mariadb-tomcat/docker-compose.yml
+++ b/16/mariadb-tomcat/docker-compose.yml
@@ -25,6 +25,10 @@ services:
   web:
     image: "xwiki:${XWIKI_VERSION}-mariadb-tomcat"
     container_name: xwiki-mariadb-tomcat-web
+    # Run an init process (tini) as PID 1 instead of the JVM, so that processes reparented to PID 1 get reaped. The JVM
+    # (our PID 1 without this) never reaps children, so any process orphaned in the container (e.g. LibreOffice children
+    # left behind when soffice.bin restarts) would otherwise linger as <defunct> zombies forever (see XDOCKER-53).
+    init: true
     depends_on:
       - db
     ports:

--- a/16/mysql-tomcat/docker-compose.yml
+++ b/16/mysql-tomcat/docker-compose.yml
@@ -25,6 +25,10 @@ services:
   web:
     image: "xwiki:${XWIKI_VERSION}-mysql-tomcat"
     container_name: xwiki-mysql-tomcat-web
+    # Run an init process (tini) as PID 1 instead of the JVM, so that processes reparented to PID 1 get reaped. The JVM
+    # (our PID 1 without this) never reaps children, so any process orphaned in the container (e.g. LibreOffice children
+    # left behind when soffice.bin restarts) would otherwise linger as <defunct> zombies forever (see XDOCKER-53).
+    init: true
     depends_on:
       - db
     ports:

--- a/16/postgres-tomcat/docker-compose.yml
+++ b/16/postgres-tomcat/docker-compose.yml
@@ -25,6 +25,10 @@ services:
   web:
     image: "xwiki:${XWIKI_VERSION}-postgres-tomcat"
     container_name: xwiki-postgres-tomcat-web
+    # Run an init process (tini) as PID 1 instead of the JVM, so that processes reparented to PID 1 get reaped. The JVM
+    # (our PID 1 without this) never reaps children, so any process orphaned in the container (e.g. LibreOffice children
+    # left behind when soffice.bin restarts) would otherwise linger as <defunct> zombies forever (see XDOCKER-53).
+    init: true
     depends_on:
       - db
     ports:

--- a/17/mariadb-tomcat/docker-compose.yml
+++ b/17/mariadb-tomcat/docker-compose.yml
@@ -25,6 +25,10 @@ services:
   web:
     image: "xwiki:${XWIKI_VERSION}-mariadb-tomcat"
     container_name: xwiki-mariadb-tomcat-web
+    # Run an init process (tini) as PID 1 instead of the JVM, so that processes reparented to PID 1 get reaped. The JVM
+    # (our PID 1 without this) never reaps children, so any process orphaned in the container (e.g. LibreOffice children
+    # left behind when soffice.bin restarts) would otherwise linger as <defunct> zombies forever (see XDOCKER-53).
+    init: true
     depends_on:
       - db
     ports:

--- a/17/mysql-tomcat/docker-compose.yml
+++ b/17/mysql-tomcat/docker-compose.yml
@@ -25,6 +25,10 @@ services:
   web:
     image: "xwiki:${XWIKI_VERSION}-mysql-tomcat"
     container_name: xwiki-mysql-tomcat-web
+    # Run an init process (tini) as PID 1 instead of the JVM, so that processes reparented to PID 1 get reaped. The JVM
+    # (our PID 1 without this) never reaps children, so any process orphaned in the container (e.g. LibreOffice children
+    # left behind when soffice.bin restarts) would otherwise linger as <defunct> zombies forever (see XDOCKER-53).
+    init: true
     depends_on:
       - db
     ports:

--- a/17/postgres-tomcat/docker-compose.yml
+++ b/17/postgres-tomcat/docker-compose.yml
@@ -25,6 +25,10 @@ services:
   web:
     image: "xwiki:${XWIKI_VERSION}-postgres-tomcat"
     container_name: xwiki-postgres-tomcat-web
+    # Run an init process (tini) as PID 1 instead of the JVM, so that processes reparented to PID 1 get reaped. The JVM
+    # (our PID 1 without this) never reaps children, so any process orphaned in the container (e.g. LibreOffice children
+    # left behind when soffice.bin restarts) would otherwise linger as <defunct> zombies forever (see XDOCKER-53).
+    init: true
     depends_on:
       - db
     ports:

--- a/18.4/mariadb-tomcat/docker-compose.yml
+++ b/18.4/mariadb-tomcat/docker-compose.yml
@@ -25,6 +25,10 @@ services:
   web:
     image: "xwiki:${XWIKI_VERSION}-mariadb-tomcat"
     container_name: xwiki-mariadb-tomcat-web
+    # Run an init process (tini) as PID 1 instead of the JVM, so that processes reparented to PID 1 get reaped. The JVM
+    # (our PID 1 without this) never reaps children, so any process orphaned in the container (e.g. LibreOffice children
+    # left behind when soffice.bin restarts) would otherwise linger as <defunct> zombies forever (see XDOCKER-53).
+    init: true
     depends_on:
       - db
     ports:

--- a/18.4/mysql-tomcat/docker-compose.yml
+++ b/18.4/mysql-tomcat/docker-compose.yml
@@ -25,6 +25,10 @@ services:
   web:
     image: "xwiki:${XWIKI_VERSION}-mysql-tomcat"
     container_name: xwiki-mysql-tomcat-web
+    # Run an init process (tini) as PID 1 instead of the JVM, so that processes reparented to PID 1 get reaped. The JVM
+    # (our PID 1 without this) never reaps children, so any process orphaned in the container (e.g. LibreOffice children
+    # left behind when soffice.bin restarts) would otherwise linger as <defunct> zombies forever (see XDOCKER-53).
+    init: true
     depends_on:
       - db
     ports:

--- a/18.4/postgres-tomcat/docker-compose.yml
+++ b/18.4/postgres-tomcat/docker-compose.yml
@@ -25,6 +25,10 @@ services:
   web:
     image: "xwiki:${XWIKI_VERSION}-postgres-tomcat"
     container_name: xwiki-postgres-tomcat-web
+    # Run an init process (tini) as PID 1 instead of the JVM, so that processes reparented to PID 1 get reaped. The JVM
+    # (our PID 1 without this) never reaps children, so any process orphaned in the container (e.g. LibreOffice children
+    # left behind when soffice.bin restarts) would otherwise linger as <defunct> zombies forever (see XDOCKER-53).
+    init: true
     depends_on:
       - db
     ports:

--- a/18/mariadb-tomcat/docker-compose.yml
+++ b/18/mariadb-tomcat/docker-compose.yml
@@ -25,6 +25,10 @@ services:
   web:
     image: "xwiki:${XWIKI_VERSION}-mariadb-tomcat"
     container_name: xwiki-mariadb-tomcat-web
+    # Run an init process (tini) as PID 1 instead of the JVM, so that processes reparented to PID 1 get reaped. The JVM
+    # (our PID 1 without this) never reaps children, so any process orphaned in the container (e.g. LibreOffice children
+    # left behind when soffice.bin restarts) would otherwise linger as <defunct> zombies forever (see XDOCKER-53).
+    init: true
     depends_on:
       - db
     ports:

--- a/18/mysql-tomcat/docker-compose.yml
+++ b/18/mysql-tomcat/docker-compose.yml
@@ -25,6 +25,10 @@ services:
   web:
     image: "xwiki:${XWIKI_VERSION}-mysql-tomcat"
     container_name: xwiki-mysql-tomcat-web
+    # Run an init process (tini) as PID 1 instead of the JVM, so that processes reparented to PID 1 get reaped. The JVM
+    # (our PID 1 without this) never reaps children, so any process orphaned in the container (e.g. LibreOffice children
+    # left behind when soffice.bin restarts) would otherwise linger as <defunct> zombies forever (see XDOCKER-53).
+    init: true
     depends_on:
       - db
     ports:

--- a/18/postgres-tomcat/docker-compose.yml
+++ b/18/postgres-tomcat/docker-compose.yml
@@ -25,6 +25,10 @@ services:
   web:
     image: "xwiki:${XWIKI_VERSION}-postgres-tomcat"
     container_name: xwiki-postgres-tomcat-web
+    # Run an init process (tini) as PID 1 instead of the JVM, so that processes reparented to PID 1 get reaped. The JVM
+    # (our PID 1 without this) never reaps children, so any process orphaned in the container (e.g. LibreOffice children
+    # left behind when soffice.bin restarts) would otherwise linger as <defunct> zombies forever (see XDOCKER-53).
+    init: true
     depends_on:
       - db
     ports:

--- a/template/docker-compose.yml
+++ b/template/docker-compose.yml
@@ -25,6 +25,10 @@ services:
   web:
     image: "xwiki:\${XWIKI_VERSION}-${db}-tomcat"
     container_name: xwiki-${db}-tomcat-web
+    # Run an init process (tini) as PID 1 instead of the JVM, so that processes reparented to PID 1 get reaped. The JVM
+    # (our PID 1 without this) never reaps children, so any process orphaned in the container (e.g. LibreOffice children
+    # left behind when soffice.bin restarts) would otherwise linger as <defunct> zombies forever (see XDOCKER-53).
+    init: true
     depends_on:
       - db
     ports:


### PR DESCRIPTION
## Jira

https://jira.xwiki.org/browse/XDOCKER-53

## Description

LibreOffice's `soffice.bin` spawns child processes and never reaps them. While `soffice.bin` is
alive those exited children are not reparented to PID 1, so no init/reaper can collect them (upstream
LibreOffice behaviour). But the `web` container ran the JVM as PID 1, which *also* never reaps — so
any LibreOffice child that gets **orphaned** (e.g. when `soffice.bin` restarts) reparents to PID 1
and lingers as `<defunct>` forever.

This adds `init: true` to the `web` service in `template/docker-compose.yml`, so tini runs as PID 1
and reaps those orphaned processes. All 12 generated `<version>/<variant>/docker-compose.yml` files
were regenerated with `./gradlew` and committed alongside the template.

## Clarifications

- This does not (and cannot) eliminate zombies whose parent `soffice.bin` is still alive — that is
  upstream LibreOffice behaviour.
- Applies to Compose users. Users running the image directly with `docker run` need to pass `--init`
  to get the same behaviour.

## Executed Tests

`./gradlew` regenerates cleanly with no leftover diff (the `gradlew-check` CI workflow enforces
this). Verified the rendered `init: true` appears in all 12 variant files.

## Expected merging strategy

Prefers squash: Yes
