### PR TITLE
XDOCKER-417: Configuration fails on read-only root filesystem

### DIFF
--- a/16/mariadb-tomcat/xwiki/docker-entrypoint.sh
+++ b/16/mariadb-tomcat/xwiki/docker-entrypoint.sh
@@ -48,10 +48,10 @@ function clean_temporary_directory() {
   mkdir -p /usr/local/xwiki/data/tmp
 }
 
-# $1 - the path to xwiki.[cfg|properties]
-# $2 - the setting/property to set
-# $3 - the new value
-function xwiki_replace() {
+# Applies a sed expression to a file, in place.
+# $1 - the file to modify
+# $2 - the sed expression to apply
+function sed_in_place() {
   # Read from a temporary copy and write the result back with a truncating redirect, instead of using "sed -i". Two
   # constraints are at play:
   # * "sed -i" creates a temporary file and performs a rename, thus changing the inode of the initial file, which makes
@@ -59,19 +59,36 @@ function xwiki_replace() {
   #   inode.
   # * The temporary copy must not be created next to the target file, because the directory holding it is not writable
   #   when the container runs with a read-only root filesystem. It goes to the temporary directory on the permanent
-  #   volume, which is writable and emptied on every start (see clean_temporary_directory).
+  #   volume, which is writable and emptied on every start (see clean_temporary_directory). mktemp restricts it to its
+  #   owner, which matters because the copy of hibernate.cfg.xml holds the database password.
   local file rc=0
   file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$1")".XXXXXX)"
   cp "$1" "${file}"
-  sed s~"\#\? \?$2 \?=.*"~"$2=$3"~g "${file}" > "$1" || rc=$?
-  # When the redirect succeeded but sed failed, the target has been truncated and must be restored from the untouched
-  # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The "-w" test tells
-  # that case apart from a redirect that never opened the target, where there is nothing to restore.
-  if [ "$rc" -ne 0 ] && [ -w "$1" ]; then
-    cp "${file}" "$1"
+  sed "$2" "${file}" > "$1" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    if [ -w "$1" ]; then
+      # The redirect succeeded but sed failed, so the target has been truncated and must be restored from the untouched
+      # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The restore is
+      # best-effort, since it can fail in turn (e.g. on a full filesystem), so that the copy below is always removed:
+      # for hibernate.cfg.xml it holds the database password.
+      cp "${file}" "$1" || echo >&2 "  ERROR: Could not restore [$1], which is now empty."
+    else
+      # The redirect could not even open the target, so there is nothing to restore. Report what to do about it: the
+      # shell's own message only names the file, and this is the expected failure when the file was left on a read-only
+      # root filesystem.
+      echo >&2 "  ERROR: Could not write to [$1]. When the container runs with a read-only root filesystem," \
+        "the XWiki configuration files must be bind-mounted individually, so that they are writable."
+    fi
   fi
   rm -f "${file}"
   return "$rc"
+}
+
+# $1 - the path to xwiki.[cfg|properties]
+# $2 - the setting/property to set
+# $3 - the new value
+function xwiki_replace() {
+  sed_in_place "$1" "s~\#\? \?$2 \?=.*~$2=$3~g"
 }
 
 # $1 - the setting/property to set
@@ -113,21 +130,9 @@ file_env() {
 # $2 - the replacement text
 # $3 - the file in which to do the search/replace
 function safesed {
-  # Same scheme as xwiki_replace: read from a temporary copy located on the permanent volume (the directory holding the
-  # target file is not writable with a read-only root filesystem) and write the result back with a truncating redirect
-  # so that the target file keeps its inode and file-level Docker volume mounts keep working.
-  local file expression rc=0
+  local expression
   expression="s/$(echo $1 | sed -e 's/\([[\/.*]\|\]\)/\\&/g')/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g"
-  file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$3")".XXXXXX)"
-  cp "$3" "${file}"
-  sed "${expression}" "${file}" > "$3" || rc=$?
-  # Restore the truncated target from the untouched copy, for the same reason and with the same "-w" test as in
-  # xwiki_replace.
-  if [ "$rc" -ne 0 ] && [ -w "$3" ]; then
-    cp "${file}" "$3"
-  fi
-  rm -f "${file}"
-  return "$rc"
+  sed_in_place "$3" "${expression}"
 }
 
 # $1 - the config file name found in WEB-INF (e.g. "xwiki.cfg")

--- a/16/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/16/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -48,10 +48,10 @@ function clean_temporary_directory() {
   mkdir -p /usr/local/xwiki/data/tmp
 }
 
-# $1 - the path to xwiki.[cfg|properties]
-# $2 - the setting/property to set
-# $3 - the new value
-function xwiki_replace() {
+# Applies a sed expression to a file, in place.
+# $1 - the file to modify
+# $2 - the sed expression to apply
+function sed_in_place() {
   # Read from a temporary copy and write the result back with a truncating redirect, instead of using "sed -i". Two
   # constraints are at play:
   # * "sed -i" creates a temporary file and performs a rename, thus changing the inode of the initial file, which makes
@@ -59,19 +59,36 @@ function xwiki_replace() {
   #   inode.
   # * The temporary copy must not be created next to the target file, because the directory holding it is not writable
   #   when the container runs with a read-only root filesystem. It goes to the temporary directory on the permanent
-  #   volume, which is writable and emptied on every start (see clean_temporary_directory).
+  #   volume, which is writable and emptied on every start (see clean_temporary_directory). mktemp restricts it to its
+  #   owner, which matters because the copy of hibernate.cfg.xml holds the database password.
   local file rc=0
   file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$1")".XXXXXX)"
   cp "$1" "${file}"
-  sed s~"\#\? \?$2 \?=.*"~"$2=$3"~g "${file}" > "$1" || rc=$?
-  # When the redirect succeeded but sed failed, the target has been truncated and must be restored from the untouched
-  # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The "-w" test tells
-  # that case apart from a redirect that never opened the target, where there is nothing to restore.
-  if [ "$rc" -ne 0 ] && [ -w "$1" ]; then
-    cp "${file}" "$1"
+  sed "$2" "${file}" > "$1" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    if [ -w "$1" ]; then
+      # The redirect succeeded but sed failed, so the target has been truncated and must be restored from the untouched
+      # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The restore is
+      # best-effort, since it can fail in turn (e.g. on a full filesystem), so that the copy below is always removed:
+      # for hibernate.cfg.xml it holds the database password.
+      cp "${file}" "$1" || echo >&2 "  ERROR: Could not restore [$1], which is now empty."
+    else
+      # The redirect could not even open the target, so there is nothing to restore. Report what to do about it: the
+      # shell's own message only names the file, and this is the expected failure when the file was left on a read-only
+      # root filesystem.
+      echo >&2 "  ERROR: Could not write to [$1]. When the container runs with a read-only root filesystem," \
+        "the XWiki configuration files must be bind-mounted individually, so that they are writable."
+    fi
   fi
   rm -f "${file}"
   return "$rc"
+}
+
+# $1 - the path to xwiki.[cfg|properties]
+# $2 - the setting/property to set
+# $3 - the new value
+function xwiki_replace() {
+  sed_in_place "$1" "s~\#\? \?$2 \?=.*~$2=$3~g"
 }
 
 # $1 - the setting/property to set
@@ -113,21 +130,9 @@ file_env() {
 # $2 - the replacement text
 # $3 - the file in which to do the search/replace
 function safesed {
-  # Same scheme as xwiki_replace: read from a temporary copy located on the permanent volume (the directory holding the
-  # target file is not writable with a read-only root filesystem) and write the result back with a truncating redirect
-  # so that the target file keeps its inode and file-level Docker volume mounts keep working.
-  local file expression rc=0
+  local expression
   expression="s/$(echo $1 | sed -e 's/\([[\/.*]\|\]\)/\\&/g')/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g"
-  file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$3")".XXXXXX)"
-  cp "$3" "${file}"
-  sed "${expression}" "${file}" > "$3" || rc=$?
-  # Restore the truncated target from the untouched copy, for the same reason and with the same "-w" test as in
-  # xwiki_replace.
-  if [ "$rc" -ne 0 ] && [ -w "$3" ]; then
-    cp "${file}" "$3"
-  fi
-  rm -f "${file}"
-  return "$rc"
+  sed_in_place "$3" "${expression}"
 }
 
 # $1 - the config file name found in WEB-INF (e.g. "xwiki.cfg")

--- a/16/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/16/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -48,10 +48,10 @@ function clean_temporary_directory() {
   mkdir -p /usr/local/xwiki/data/tmp
 }
 
-# $1 - the path to xwiki.[cfg|properties]
-# $2 - the setting/property to set
-# $3 - the new value
-function xwiki_replace() {
+# Applies a sed expression to a file, in place.
+# $1 - the file to modify
+# $2 - the sed expression to apply
+function sed_in_place() {
   # Read from a temporary copy and write the result back with a truncating redirect, instead of using "sed -i". Two
   # constraints are at play:
   # * "sed -i" creates a temporary file and performs a rename, thus changing the inode of the initial file, which makes
@@ -59,19 +59,36 @@ function xwiki_replace() {
   #   inode.
   # * The temporary copy must not be created next to the target file, because the directory holding it is not writable
   #   when the container runs with a read-only root filesystem. It goes to the temporary directory on the permanent
-  #   volume, which is writable and emptied on every start (see clean_temporary_directory).
+  #   volume, which is writable and emptied on every start (see clean_temporary_directory). mktemp restricts it to its
+  #   owner, which matters because the copy of hibernate.cfg.xml holds the database password.
   local file rc=0
   file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$1")".XXXXXX)"
   cp "$1" "${file}"
-  sed s~"\#\? \?$2 \?=.*"~"$2=$3"~g "${file}" > "$1" || rc=$?
-  # When the redirect succeeded but sed failed, the target has been truncated and must be restored from the untouched
-  # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The "-w" test tells
-  # that case apart from a redirect that never opened the target, where there is nothing to restore.
-  if [ "$rc" -ne 0 ] && [ -w "$1" ]; then
-    cp "${file}" "$1"
+  sed "$2" "${file}" > "$1" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    if [ -w "$1" ]; then
+      # The redirect succeeded but sed failed, so the target has been truncated and must be restored from the untouched
+      # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The restore is
+      # best-effort, since it can fail in turn (e.g. on a full filesystem), so that the copy below is always removed:
+      # for hibernate.cfg.xml it holds the database password.
+      cp "${file}" "$1" || echo >&2 "  ERROR: Could not restore [$1], which is now empty."
+    else
+      # The redirect could not even open the target, so there is nothing to restore. Report what to do about it: the
+      # shell's own message only names the file, and this is the expected failure when the file was left on a read-only
+      # root filesystem.
+      echo >&2 "  ERROR: Could not write to [$1]. When the container runs with a read-only root filesystem," \
+        "the XWiki configuration files must be bind-mounted individually, so that they are writable."
+    fi
   fi
   rm -f "${file}"
   return "$rc"
+}
+
+# $1 - the path to xwiki.[cfg|properties]
+# $2 - the setting/property to set
+# $3 - the new value
+function xwiki_replace() {
+  sed_in_place "$1" "s~\#\? \?$2 \?=.*~$2=$3~g"
 }
 
 # $1 - the setting/property to set
@@ -113,21 +130,9 @@ file_env() {
 # $2 - the replacement text
 # $3 - the file in which to do the search/replace
 function safesed {
-  # Same scheme as xwiki_replace: read from a temporary copy located on the permanent volume (the directory holding the
-  # target file is not writable with a read-only root filesystem) and write the result back with a truncating redirect
-  # so that the target file keeps its inode and file-level Docker volume mounts keep working.
-  local file expression rc=0
+  local expression
   expression="s/$(echo $1 | sed -e 's/\([[\/.*]\|\]\)/\\&/g')/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g"
-  file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$3")".XXXXXX)"
-  cp "$3" "${file}"
-  sed "${expression}" "${file}" > "$3" || rc=$?
-  # Restore the truncated target from the untouched copy, for the same reason and with the same "-w" test as in
-  # xwiki_replace.
-  if [ "$rc" -ne 0 ] && [ -w "$3" ]; then
-    cp "${file}" "$3"
-  fi
-  rm -f "${file}"
-  return "$rc"
+  sed_in_place "$3" "${expression}"
 }
 
 # $1 - the config file name found in WEB-INF (e.g. "xwiki.cfg")

--- a/17/mariadb-tomcat/xwiki/docker-entrypoint.sh
+++ b/17/mariadb-tomcat/xwiki/docker-entrypoint.sh
@@ -48,10 +48,10 @@ function clean_temporary_directory() {
   mkdir -p /usr/local/xwiki/data/tmp
 }
 
-# $1 - the path to xwiki.[cfg|properties]
-# $2 - the setting/property to set
-# $3 - the new value
-function xwiki_replace() {
+# Applies a sed expression to a file, in place.
+# $1 - the file to modify
+# $2 - the sed expression to apply
+function sed_in_place() {
   # Read from a temporary copy and write the result back with a truncating redirect, instead of using "sed -i". Two
   # constraints are at play:
   # * "sed -i" creates a temporary file and performs a rename, thus changing the inode of the initial file, which makes
@@ -59,19 +59,36 @@ function xwiki_replace() {
   #   inode.
   # * The temporary copy must not be created next to the target file, because the directory holding it is not writable
   #   when the container runs with a read-only root filesystem. It goes to the temporary directory on the permanent
-  #   volume, which is writable and emptied on every start (see clean_temporary_directory).
+  #   volume, which is writable and emptied on every start (see clean_temporary_directory). mktemp restricts it to its
+  #   owner, which matters because the copy of hibernate.cfg.xml holds the database password.
   local file rc=0
   file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$1")".XXXXXX)"
   cp "$1" "${file}"
-  sed s~"\#\? \?$2 \?=.*"~"$2=$3"~g "${file}" > "$1" || rc=$?
-  # When the redirect succeeded but sed failed, the target has been truncated and must be restored from the untouched
-  # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The "-w" test tells
-  # that case apart from a redirect that never opened the target, where there is nothing to restore.
-  if [ "$rc" -ne 0 ] && [ -w "$1" ]; then
-    cp "${file}" "$1"
+  sed "$2" "${file}" > "$1" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    if [ -w "$1" ]; then
+      # The redirect succeeded but sed failed, so the target has been truncated and must be restored from the untouched
+      # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The restore is
+      # best-effort, since it can fail in turn (e.g. on a full filesystem), so that the copy below is always removed:
+      # for hibernate.cfg.xml it holds the database password.
+      cp "${file}" "$1" || echo >&2 "  ERROR: Could not restore [$1], which is now empty."
+    else
+      # The redirect could not even open the target, so there is nothing to restore. Report what to do about it: the
+      # shell's own message only names the file, and this is the expected failure when the file was left on a read-only
+      # root filesystem.
+      echo >&2 "  ERROR: Could not write to [$1]. When the container runs with a read-only root filesystem," \
+        "the XWiki configuration files must be bind-mounted individually, so that they are writable."
+    fi
   fi
   rm -f "${file}"
   return "$rc"
+}
+
+# $1 - the path to xwiki.[cfg|properties]
+# $2 - the setting/property to set
+# $3 - the new value
+function xwiki_replace() {
+  sed_in_place "$1" "s~\#\? \?$2 \?=.*~$2=$3~g"
 }
 
 # $1 - the setting/property to set
@@ -113,21 +130,9 @@ file_env() {
 # $2 - the replacement text
 # $3 - the file in which to do the search/replace
 function safesed {
-  # Same scheme as xwiki_replace: read from a temporary copy located on the permanent volume (the directory holding the
-  # target file is not writable with a read-only root filesystem) and write the result back with a truncating redirect
-  # so that the target file keeps its inode and file-level Docker volume mounts keep working.
-  local file expression rc=0
+  local expression
   expression="s/$(echo $1 | sed -e 's/\([[\/.*]\|\]\)/\\&/g')/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g"
-  file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$3")".XXXXXX)"
-  cp "$3" "${file}"
-  sed "${expression}" "${file}" > "$3" || rc=$?
-  # Restore the truncated target from the untouched copy, for the same reason and with the same "-w" test as in
-  # xwiki_replace.
-  if [ "$rc" -ne 0 ] && [ -w "$3" ]; then
-    cp "${file}" "$3"
-  fi
-  rm -f "${file}"
-  return "$rc"
+  sed_in_place "$3" "${expression}"
 }
 
 # $1 - the config file name found in WEB-INF (e.g. "xwiki.cfg")

--- a/17/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/17/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -48,10 +48,10 @@ function clean_temporary_directory() {
   mkdir -p /usr/local/xwiki/data/tmp
 }
 
-# $1 - the path to xwiki.[cfg|properties]
-# $2 - the setting/property to set
-# $3 - the new value
-function xwiki_replace() {
+# Applies a sed expression to a file, in place.
+# $1 - the file to modify
+# $2 - the sed expression to apply
+function sed_in_place() {
   # Read from a temporary copy and write the result back with a truncating redirect, instead of using "sed -i". Two
   # constraints are at play:
   # * "sed -i" creates a temporary file and performs a rename, thus changing the inode of the initial file, which makes
@@ -59,19 +59,36 @@ function xwiki_replace() {
   #   inode.
   # * The temporary copy must not be created next to the target file, because the directory holding it is not writable
   #   when the container runs with a read-only root filesystem. It goes to the temporary directory on the permanent
-  #   volume, which is writable and emptied on every start (see clean_temporary_directory).
+  #   volume, which is writable and emptied on every start (see clean_temporary_directory). mktemp restricts it to its
+  #   owner, which matters because the copy of hibernate.cfg.xml holds the database password.
   local file rc=0
   file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$1")".XXXXXX)"
   cp "$1" "${file}"
-  sed s~"\#\? \?$2 \?=.*"~"$2=$3"~g "${file}" > "$1" || rc=$?
-  # When the redirect succeeded but sed failed, the target has been truncated and must be restored from the untouched
-  # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The "-w" test tells
-  # that case apart from a redirect that never opened the target, where there is nothing to restore.
-  if [ "$rc" -ne 0 ] && [ -w "$1" ]; then
-    cp "${file}" "$1"
+  sed "$2" "${file}" > "$1" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    if [ -w "$1" ]; then
+      # The redirect succeeded but sed failed, so the target has been truncated and must be restored from the untouched
+      # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The restore is
+      # best-effort, since it can fail in turn (e.g. on a full filesystem), so that the copy below is always removed:
+      # for hibernate.cfg.xml it holds the database password.
+      cp "${file}" "$1" || echo >&2 "  ERROR: Could not restore [$1], which is now empty."
+    else
+      # The redirect could not even open the target, so there is nothing to restore. Report what to do about it: the
+      # shell's own message only names the file, and this is the expected failure when the file was left on a read-only
+      # root filesystem.
+      echo >&2 "  ERROR: Could not write to [$1]. When the container runs with a read-only root filesystem," \
+        "the XWiki configuration files must be bind-mounted individually, so that they are writable."
+    fi
   fi
   rm -f "${file}"
   return "$rc"
+}
+
+# $1 - the path to xwiki.[cfg|properties]
+# $2 - the setting/property to set
+# $3 - the new value
+function xwiki_replace() {
+  sed_in_place "$1" "s~\#\? \?$2 \?=.*~$2=$3~g"
 }
 
 # $1 - the setting/property to set
@@ -113,21 +130,9 @@ file_env() {
 # $2 - the replacement text
 # $3 - the file in which to do the search/replace
 function safesed {
-  # Same scheme as xwiki_replace: read from a temporary copy located on the permanent volume (the directory holding the
-  # target file is not writable with a read-only root filesystem) and write the result back with a truncating redirect
-  # so that the target file keeps its inode and file-level Docker volume mounts keep working.
-  local file expression rc=0
+  local expression
   expression="s/$(echo $1 | sed -e 's/\([[\/.*]\|\]\)/\\&/g')/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g"
-  file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$3")".XXXXXX)"
-  cp "$3" "${file}"
-  sed "${expression}" "${file}" > "$3" || rc=$?
-  # Restore the truncated target from the untouched copy, for the same reason and with the same "-w" test as in
-  # xwiki_replace.
-  if [ "$rc" -ne 0 ] && [ -w "$3" ]; then
-    cp "${file}" "$3"
-  fi
-  rm -f "${file}"
-  return "$rc"
+  sed_in_place "$3" "${expression}"
 }
 
 # $1 - the config file name found in WEB-INF (e.g. "xwiki.cfg")

--- a/17/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/17/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -48,10 +48,10 @@ function clean_temporary_directory() {
   mkdir -p /usr/local/xwiki/data/tmp
 }
 
-# $1 - the path to xwiki.[cfg|properties]
-# $2 - the setting/property to set
-# $3 - the new value
-function xwiki_replace() {
+# Applies a sed expression to a file, in place.
+# $1 - the file to modify
+# $2 - the sed expression to apply
+function sed_in_place() {
   # Read from a temporary copy and write the result back with a truncating redirect, instead of using "sed -i". Two
   # constraints are at play:
   # * "sed -i" creates a temporary file and performs a rename, thus changing the inode of the initial file, which makes
@@ -59,19 +59,36 @@ function xwiki_replace() {
   #   inode.
   # * The temporary copy must not be created next to the target file, because the directory holding it is not writable
   #   when the container runs with a read-only root filesystem. It goes to the temporary directory on the permanent
-  #   volume, which is writable and emptied on every start (see clean_temporary_directory).
+  #   volume, which is writable and emptied on every start (see clean_temporary_directory). mktemp restricts it to its
+  #   owner, which matters because the copy of hibernate.cfg.xml holds the database password.
   local file rc=0
   file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$1")".XXXXXX)"
   cp "$1" "${file}"
-  sed s~"\#\? \?$2 \?=.*"~"$2=$3"~g "${file}" > "$1" || rc=$?
-  # When the redirect succeeded but sed failed, the target has been truncated and must be restored from the untouched
-  # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The "-w" test tells
-  # that case apart from a redirect that never opened the target, where there is nothing to restore.
-  if [ "$rc" -ne 0 ] && [ -w "$1" ]; then
-    cp "${file}" "$1"
+  sed "$2" "${file}" > "$1" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    if [ -w "$1" ]; then
+      # The redirect succeeded but sed failed, so the target has been truncated and must be restored from the untouched
+      # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The restore is
+      # best-effort, since it can fail in turn (e.g. on a full filesystem), so that the copy below is always removed:
+      # for hibernate.cfg.xml it holds the database password.
+      cp "${file}" "$1" || echo >&2 "  ERROR: Could not restore [$1], which is now empty."
+    else
+      # The redirect could not even open the target, so there is nothing to restore. Report what to do about it: the
+      # shell's own message only names the file, and this is the expected failure when the file was left on a read-only
+      # root filesystem.
+      echo >&2 "  ERROR: Could not write to [$1]. When the container runs with a read-only root filesystem," \
+        "the XWiki configuration files must be bind-mounted individually, so that they are writable."
+    fi
   fi
   rm -f "${file}"
   return "$rc"
+}
+
+# $1 - the path to xwiki.[cfg|properties]
+# $2 - the setting/property to set
+# $3 - the new value
+function xwiki_replace() {
+  sed_in_place "$1" "s~\#\? \?$2 \?=.*~$2=$3~g"
 }
 
 # $1 - the setting/property to set
@@ -113,21 +130,9 @@ file_env() {
 # $2 - the replacement text
 # $3 - the file in which to do the search/replace
 function safesed {
-  # Same scheme as xwiki_replace: read from a temporary copy located on the permanent volume (the directory holding the
-  # target file is not writable with a read-only root filesystem) and write the result back with a truncating redirect
-  # so that the target file keeps its inode and file-level Docker volume mounts keep working.
-  local file expression rc=0
+  local expression
   expression="s/$(echo $1 | sed -e 's/\([[\/.*]\|\]\)/\\&/g')/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g"
-  file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$3")".XXXXXX)"
-  cp "$3" "${file}"
-  sed "${expression}" "${file}" > "$3" || rc=$?
-  # Restore the truncated target from the untouched copy, for the same reason and with the same "-w" test as in
-  # xwiki_replace.
-  if [ "$rc" -ne 0 ] && [ -w "$3" ]; then
-    cp "${file}" "$3"
-  fi
-  rm -f "${file}"
-  return "$rc"
+  sed_in_place "$3" "${expression}"
 }
 
 # $1 - the config file name found in WEB-INF (e.g. "xwiki.cfg")

--- a/18.4/mariadb-tomcat/xwiki/docker-entrypoint.sh
+++ b/18.4/mariadb-tomcat/xwiki/docker-entrypoint.sh
@@ -48,10 +48,10 @@ function clean_temporary_directory() {
   mkdir -p /usr/local/xwiki/data/tmp
 }
 
-# $1 - the path to xwiki.[cfg|properties]
-# $2 - the setting/property to set
-# $3 - the new value
-function xwiki_replace() {
+# Applies a sed expression to a file, in place.
+# $1 - the file to modify
+# $2 - the sed expression to apply
+function sed_in_place() {
   # Read from a temporary copy and write the result back with a truncating redirect, instead of using "sed -i". Two
   # constraints are at play:
   # * "sed -i" creates a temporary file and performs a rename, thus changing the inode of the initial file, which makes
@@ -59,19 +59,36 @@ function xwiki_replace() {
   #   inode.
   # * The temporary copy must not be created next to the target file, because the directory holding it is not writable
   #   when the container runs with a read-only root filesystem. It goes to the temporary directory on the permanent
-  #   volume, which is writable and emptied on every start (see clean_temporary_directory).
+  #   volume, which is writable and emptied on every start (see clean_temporary_directory). mktemp restricts it to its
+  #   owner, which matters because the copy of hibernate.cfg.xml holds the database password.
   local file rc=0
   file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$1")".XXXXXX)"
   cp "$1" "${file}"
-  sed s~"\#\? \?$2 \?=.*"~"$2=$3"~g "${file}" > "$1" || rc=$?
-  # When the redirect succeeded but sed failed, the target has been truncated and must be restored from the untouched
-  # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The "-w" test tells
-  # that case apart from a redirect that never opened the target, where there is nothing to restore.
-  if [ "$rc" -ne 0 ] && [ -w "$1" ]; then
-    cp "${file}" "$1"
+  sed "$2" "${file}" > "$1" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    if [ -w "$1" ]; then
+      # The redirect succeeded but sed failed, so the target has been truncated and must be restored from the untouched
+      # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The restore is
+      # best-effort, since it can fail in turn (e.g. on a full filesystem), so that the copy below is always removed:
+      # for hibernate.cfg.xml it holds the database password.
+      cp "${file}" "$1" || echo >&2 "  ERROR: Could not restore [$1], which is now empty."
+    else
+      # The redirect could not even open the target, so there is nothing to restore. Report what to do about it: the
+      # shell's own message only names the file, and this is the expected failure when the file was left on a read-only
+      # root filesystem.
+      echo >&2 "  ERROR: Could not write to [$1]. When the container runs with a read-only root filesystem," \
+        "the XWiki configuration files must be bind-mounted individually, so that they are writable."
+    fi
   fi
   rm -f "${file}"
   return "$rc"
+}
+
+# $1 - the path to xwiki.[cfg|properties]
+# $2 - the setting/property to set
+# $3 - the new value
+function xwiki_replace() {
+  sed_in_place "$1" "s~\#\? \?$2 \?=.*~$2=$3~g"
 }
 
 # $1 - the setting/property to set
@@ -113,21 +130,9 @@ file_env() {
 # $2 - the replacement text
 # $3 - the file in which to do the search/replace
 function safesed {
-  # Same scheme as xwiki_replace: read from a temporary copy located on the permanent volume (the directory holding the
-  # target file is not writable with a read-only root filesystem) and write the result back with a truncating redirect
-  # so that the target file keeps its inode and file-level Docker volume mounts keep working.
-  local file expression rc=0
+  local expression
   expression="s/$(echo $1 | sed -e 's/\([[\/.*]\|\]\)/\\&/g')/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g"
-  file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$3")".XXXXXX)"
-  cp "$3" "${file}"
-  sed "${expression}" "${file}" > "$3" || rc=$?
-  # Restore the truncated target from the untouched copy, for the same reason and with the same "-w" test as in
-  # xwiki_replace.
-  if [ "$rc" -ne 0 ] && [ -w "$3" ]; then
-    cp "${file}" "$3"
-  fi
-  rm -f "${file}"
-  return "$rc"
+  sed_in_place "$3" "${expression}"
 }
 
 # $1 - the config file name found in WEB-INF (e.g. "xwiki.cfg")

--- a/18.4/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/18.4/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -48,10 +48,10 @@ function clean_temporary_directory() {
   mkdir -p /usr/local/xwiki/data/tmp
 }
 
-# $1 - the path to xwiki.[cfg|properties]
-# $2 - the setting/property to set
-# $3 - the new value
-function xwiki_replace() {
+# Applies a sed expression to a file, in place.
+# $1 - the file to modify
+# $2 - the sed expression to apply
+function sed_in_place() {
   # Read from a temporary copy and write the result back with a truncating redirect, instead of using "sed -i". Two
   # constraints are at play:
   # * "sed -i" creates a temporary file and performs a rename, thus changing the inode of the initial file, which makes
@@ -59,19 +59,36 @@ function xwiki_replace() {
   #   inode.
   # * The temporary copy must not be created next to the target file, because the directory holding it is not writable
   #   when the container runs with a read-only root filesystem. It goes to the temporary directory on the permanent
-  #   volume, which is writable and emptied on every start (see clean_temporary_directory).
+  #   volume, which is writable and emptied on every start (see clean_temporary_directory). mktemp restricts it to its
+  #   owner, which matters because the copy of hibernate.cfg.xml holds the database password.
   local file rc=0
   file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$1")".XXXXXX)"
   cp "$1" "${file}"
-  sed s~"\#\? \?$2 \?=.*"~"$2=$3"~g "${file}" > "$1" || rc=$?
-  # When the redirect succeeded but sed failed, the target has been truncated and must be restored from the untouched
-  # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The "-w" test tells
-  # that case apart from a redirect that never opened the target, where there is nothing to restore.
-  if [ "$rc" -ne 0 ] && [ -w "$1" ]; then
-    cp "${file}" "$1"
+  sed "$2" "${file}" > "$1" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    if [ -w "$1" ]; then
+      # The redirect succeeded but sed failed, so the target has been truncated and must be restored from the untouched
+      # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The restore is
+      # best-effort, since it can fail in turn (e.g. on a full filesystem), so that the copy below is always removed:
+      # for hibernate.cfg.xml it holds the database password.
+      cp "${file}" "$1" || echo >&2 "  ERROR: Could not restore [$1], which is now empty."
+    else
+      # The redirect could not even open the target, so there is nothing to restore. Report what to do about it: the
+      # shell's own message only names the file, and this is the expected failure when the file was left on a read-only
+      # root filesystem.
+      echo >&2 "  ERROR: Could not write to [$1]. When the container runs with a read-only root filesystem," \
+        "the XWiki configuration files must be bind-mounted individually, so that they are writable."
+    fi
   fi
   rm -f "${file}"
   return "$rc"
+}
+
+# $1 - the path to xwiki.[cfg|properties]
+# $2 - the setting/property to set
+# $3 - the new value
+function xwiki_replace() {
+  sed_in_place "$1" "s~\#\? \?$2 \?=.*~$2=$3~g"
 }
 
 # $1 - the setting/property to set
@@ -113,21 +130,9 @@ file_env() {
 # $2 - the replacement text
 # $3 - the file in which to do the search/replace
 function safesed {
-  # Same scheme as xwiki_replace: read from a temporary copy located on the permanent volume (the directory holding the
-  # target file is not writable with a read-only root filesystem) and write the result back with a truncating redirect
-  # so that the target file keeps its inode and file-level Docker volume mounts keep working.
-  local file expression rc=0
+  local expression
   expression="s/$(echo $1 | sed -e 's/\([[\/.*]\|\]\)/\\&/g')/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g"
-  file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$3")".XXXXXX)"
-  cp "$3" "${file}"
-  sed "${expression}" "${file}" > "$3" || rc=$?
-  # Restore the truncated target from the untouched copy, for the same reason and with the same "-w" test as in
-  # xwiki_replace.
-  if [ "$rc" -ne 0 ] && [ -w "$3" ]; then
-    cp "${file}" "$3"
-  fi
-  rm -f "${file}"
-  return "$rc"
+  sed_in_place "$3" "${expression}"
 }
 
 # $1 - the config file name found in WEB-INF (e.g. "xwiki.cfg")

--- a/18.4/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/18.4/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -48,10 +48,10 @@ function clean_temporary_directory() {
   mkdir -p /usr/local/xwiki/data/tmp
 }
 
-# $1 - the path to xwiki.[cfg|properties]
-# $2 - the setting/property to set
-# $3 - the new value
-function xwiki_replace() {
+# Applies a sed expression to a file, in place.
+# $1 - the file to modify
+# $2 - the sed expression to apply
+function sed_in_place() {
   # Read from a temporary copy and write the result back with a truncating redirect, instead of using "sed -i". Two
   # constraints are at play:
   # * "sed -i" creates a temporary file and performs a rename, thus changing the inode of the initial file, which makes
@@ -59,19 +59,36 @@ function xwiki_replace() {
   #   inode.
   # * The temporary copy must not be created next to the target file, because the directory holding it is not writable
   #   when the container runs with a read-only root filesystem. It goes to the temporary directory on the permanent
-  #   volume, which is writable and emptied on every start (see clean_temporary_directory).
+  #   volume, which is writable and emptied on every start (see clean_temporary_directory). mktemp restricts it to its
+  #   owner, which matters because the copy of hibernate.cfg.xml holds the database password.
   local file rc=0
   file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$1")".XXXXXX)"
   cp "$1" "${file}"
-  sed s~"\#\? \?$2 \?=.*"~"$2=$3"~g "${file}" > "$1" || rc=$?
-  # When the redirect succeeded but sed failed, the target has been truncated and must be restored from the untouched
-  # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The "-w" test tells
-  # that case apart from a redirect that never opened the target, where there is nothing to restore.
-  if [ "$rc" -ne 0 ] && [ -w "$1" ]; then
-    cp "${file}" "$1"
+  sed "$2" "${file}" > "$1" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    if [ -w "$1" ]; then
+      # The redirect succeeded but sed failed, so the target has been truncated and must be restored from the untouched
+      # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The restore is
+      # best-effort, since it can fail in turn (e.g. on a full filesystem), so that the copy below is always removed:
+      # for hibernate.cfg.xml it holds the database password.
+      cp "${file}" "$1" || echo >&2 "  ERROR: Could not restore [$1], which is now empty."
+    else
+      # The redirect could not even open the target, so there is nothing to restore. Report what to do about it: the
+      # shell's own message only names the file, and this is the expected failure when the file was left on a read-only
+      # root filesystem.
+      echo >&2 "  ERROR: Could not write to [$1]. When the container runs with a read-only root filesystem," \
+        "the XWiki configuration files must be bind-mounted individually, so that they are writable."
+    fi
   fi
   rm -f "${file}"
   return "$rc"
+}
+
+# $1 - the path to xwiki.[cfg|properties]
+# $2 - the setting/property to set
+# $3 - the new value
+function xwiki_replace() {
+  sed_in_place "$1" "s~\#\? \?$2 \?=.*~$2=$3~g"
 }
 
 # $1 - the setting/property to set
@@ -113,21 +130,9 @@ file_env() {
 # $2 - the replacement text
 # $3 - the file in which to do the search/replace
 function safesed {
-  # Same scheme as xwiki_replace: read from a temporary copy located on the permanent volume (the directory holding the
-  # target file is not writable with a read-only root filesystem) and write the result back with a truncating redirect
-  # so that the target file keeps its inode and file-level Docker volume mounts keep working.
-  local file expression rc=0
+  local expression
   expression="s/$(echo $1 | sed -e 's/\([[\/.*]\|\]\)/\\&/g')/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g"
-  file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$3")".XXXXXX)"
-  cp "$3" "${file}"
-  sed "${expression}" "${file}" > "$3" || rc=$?
-  # Restore the truncated target from the untouched copy, for the same reason and with the same "-w" test as in
-  # xwiki_replace.
-  if [ "$rc" -ne 0 ] && [ -w "$3" ]; then
-    cp "${file}" "$3"
-  fi
-  rm -f "${file}"
-  return "$rc"
+  sed_in_place "$3" "${expression}"
 }
 
 # $1 - the config file name found in WEB-INF (e.g. "xwiki.cfg")

--- a/18/mariadb-tomcat/xwiki/docker-entrypoint.sh
+++ b/18/mariadb-tomcat/xwiki/docker-entrypoint.sh
@@ -48,10 +48,10 @@ function clean_temporary_directory() {
   mkdir -p /usr/local/xwiki/data/tmp
 }
 
-# $1 - the path to xwiki.[cfg|properties]
-# $2 - the setting/property to set
-# $3 - the new value
-function xwiki_replace() {
+# Applies a sed expression to a file, in place.
+# $1 - the file to modify
+# $2 - the sed expression to apply
+function sed_in_place() {
   # Read from a temporary copy and write the result back with a truncating redirect, instead of using "sed -i". Two
   # constraints are at play:
   # * "sed -i" creates a temporary file and performs a rename, thus changing the inode of the initial file, which makes
@@ -59,19 +59,36 @@ function xwiki_replace() {
   #   inode.
   # * The temporary copy must not be created next to the target file, because the directory holding it is not writable
   #   when the container runs with a read-only root filesystem. It goes to the temporary directory on the permanent
-  #   volume, which is writable and emptied on every start (see clean_temporary_directory).
+  #   volume, which is writable and emptied on every start (see clean_temporary_directory). mktemp restricts it to its
+  #   owner, which matters because the copy of hibernate.cfg.xml holds the database password.
   local file rc=0
   file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$1")".XXXXXX)"
   cp "$1" "${file}"
-  sed s~"\#\? \?$2 \?=.*"~"$2=$3"~g "${file}" > "$1" || rc=$?
-  # When the redirect succeeded but sed failed, the target has been truncated and must be restored from the untouched
-  # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The "-w" test tells
-  # that case apart from a redirect that never opened the target, where there is nothing to restore.
-  if [ "$rc" -ne 0 ] && [ -w "$1" ]; then
-    cp "${file}" "$1"
+  sed "$2" "${file}" > "$1" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    if [ -w "$1" ]; then
+      # The redirect succeeded but sed failed, so the target has been truncated and must be restored from the untouched
+      # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The restore is
+      # best-effort, since it can fail in turn (e.g. on a full filesystem), so that the copy below is always removed:
+      # for hibernate.cfg.xml it holds the database password.
+      cp "${file}" "$1" || echo >&2 "  ERROR: Could not restore [$1], which is now empty."
+    else
+      # The redirect could not even open the target, so there is nothing to restore. Report what to do about it: the
+      # shell's own message only names the file, and this is the expected failure when the file was left on a read-only
+      # root filesystem.
+      echo >&2 "  ERROR: Could not write to [$1]. When the container runs with a read-only root filesystem," \
+        "the XWiki configuration files must be bind-mounted individually, so that they are writable."
+    fi
   fi
   rm -f "${file}"
   return "$rc"
+}
+
+# $1 - the path to xwiki.[cfg|properties]
+# $2 - the setting/property to set
+# $3 - the new value
+function xwiki_replace() {
+  sed_in_place "$1" "s~\#\? \?$2 \?=.*~$2=$3~g"
 }
 
 # $1 - the setting/property to set
@@ -113,21 +130,9 @@ file_env() {
 # $2 - the replacement text
 # $3 - the file in which to do the search/replace
 function safesed {
-  # Same scheme as xwiki_replace: read from a temporary copy located on the permanent volume (the directory holding the
-  # target file is not writable with a read-only root filesystem) and write the result back with a truncating redirect
-  # so that the target file keeps its inode and file-level Docker volume mounts keep working.
-  local file expression rc=0
+  local expression
   expression="s/$(echo $1 | sed -e 's/\([[\/.*]\|\]\)/\\&/g')/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g"
-  file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$3")".XXXXXX)"
-  cp "$3" "${file}"
-  sed "${expression}" "${file}" > "$3" || rc=$?
-  # Restore the truncated target from the untouched copy, for the same reason and with the same "-w" test as in
-  # xwiki_replace.
-  if [ "$rc" -ne 0 ] && [ -w "$3" ]; then
-    cp "${file}" "$3"
-  fi
-  rm -f "${file}"
-  return "$rc"
+  sed_in_place "$3" "${expression}"
 }
 
 # $1 - the config file name found in WEB-INF (e.g. "xwiki.cfg")

--- a/18/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/18/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -48,10 +48,10 @@ function clean_temporary_directory() {
   mkdir -p /usr/local/xwiki/data/tmp
 }
 
-# $1 - the path to xwiki.[cfg|properties]
-# $2 - the setting/property to set
-# $3 - the new value
-function xwiki_replace() {
+# Applies a sed expression to a file, in place.
+# $1 - the file to modify
+# $2 - the sed expression to apply
+function sed_in_place() {
   # Read from a temporary copy and write the result back with a truncating redirect, instead of using "sed -i". Two
   # constraints are at play:
   # * "sed -i" creates a temporary file and performs a rename, thus changing the inode of the initial file, which makes
@@ -59,19 +59,36 @@ function xwiki_replace() {
   #   inode.
   # * The temporary copy must not be created next to the target file, because the directory holding it is not writable
   #   when the container runs with a read-only root filesystem. It goes to the temporary directory on the permanent
-  #   volume, which is writable and emptied on every start (see clean_temporary_directory).
+  #   volume, which is writable and emptied on every start (see clean_temporary_directory). mktemp restricts it to its
+  #   owner, which matters because the copy of hibernate.cfg.xml holds the database password.
   local file rc=0
   file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$1")".XXXXXX)"
   cp "$1" "${file}"
-  sed s~"\#\? \?$2 \?=.*"~"$2=$3"~g "${file}" > "$1" || rc=$?
-  # When the redirect succeeded but sed failed, the target has been truncated and must be restored from the untouched
-  # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The "-w" test tells
-  # that case apart from a redirect that never opened the target, where there is nothing to restore.
-  if [ "$rc" -ne 0 ] && [ -w "$1" ]; then
-    cp "${file}" "$1"
+  sed "$2" "${file}" > "$1" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    if [ -w "$1" ]; then
+      # The redirect succeeded but sed failed, so the target has been truncated and must be restored from the untouched
+      # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The restore is
+      # best-effort, since it can fail in turn (e.g. on a full filesystem), so that the copy below is always removed:
+      # for hibernate.cfg.xml it holds the database password.
+      cp "${file}" "$1" || echo >&2 "  ERROR: Could not restore [$1], which is now empty."
+    else
+      # The redirect could not even open the target, so there is nothing to restore. Report what to do about it: the
+      # shell's own message only names the file, and this is the expected failure when the file was left on a read-only
+      # root filesystem.
+      echo >&2 "  ERROR: Could not write to [$1]. When the container runs with a read-only root filesystem," \
+        "the XWiki configuration files must be bind-mounted individually, so that they are writable."
+    fi
   fi
   rm -f "${file}"
   return "$rc"
+}
+
+# $1 - the path to xwiki.[cfg|properties]
+# $2 - the setting/property to set
+# $3 - the new value
+function xwiki_replace() {
+  sed_in_place "$1" "s~\#\? \?$2 \?=.*~$2=$3~g"
 }
 
 # $1 - the setting/property to set
@@ -113,21 +130,9 @@ file_env() {
 # $2 - the replacement text
 # $3 - the file in which to do the search/replace
 function safesed {
-  # Same scheme as xwiki_replace: read from a temporary copy located on the permanent volume (the directory holding the
-  # target file is not writable with a read-only root filesystem) and write the result back with a truncating redirect
-  # so that the target file keeps its inode and file-level Docker volume mounts keep working.
-  local file expression rc=0
+  local expression
   expression="s/$(echo $1 | sed -e 's/\([[\/.*]\|\]\)/\\&/g')/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g"
-  file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$3")".XXXXXX)"
-  cp "$3" "${file}"
-  sed "${expression}" "${file}" > "$3" || rc=$?
-  # Restore the truncated target from the untouched copy, for the same reason and with the same "-w" test as in
-  # xwiki_replace.
-  if [ "$rc" -ne 0 ] && [ -w "$3" ]; then
-    cp "${file}" "$3"
-  fi
-  rm -f "${file}"
-  return "$rc"
+  sed_in_place "$3" "${expression}"
 }
 
 # $1 - the config file name found in WEB-INF (e.g. "xwiki.cfg")

--- a/18/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/18/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -48,10 +48,10 @@ function clean_temporary_directory() {
   mkdir -p /usr/local/xwiki/data/tmp
 }
 
-# $1 - the path to xwiki.[cfg|properties]
-# $2 - the setting/property to set
-# $3 - the new value
-function xwiki_replace() {
+# Applies a sed expression to a file, in place.
+# $1 - the file to modify
+# $2 - the sed expression to apply
+function sed_in_place() {
   # Read from a temporary copy and write the result back with a truncating redirect, instead of using "sed -i". Two
   # constraints are at play:
   # * "sed -i" creates a temporary file and performs a rename, thus changing the inode of the initial file, which makes
@@ -59,19 +59,36 @@ function xwiki_replace() {
   #   inode.
   # * The temporary copy must not be created next to the target file, because the directory holding it is not writable
   #   when the container runs with a read-only root filesystem. It goes to the temporary directory on the permanent
-  #   volume, which is writable and emptied on every start (see clean_temporary_directory).
+  #   volume, which is writable and emptied on every start (see clean_temporary_directory). mktemp restricts it to its
+  #   owner, which matters because the copy of hibernate.cfg.xml holds the database password.
   local file rc=0
   file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$1")".XXXXXX)"
   cp "$1" "${file}"
-  sed s~"\#\? \?$2 \?=.*"~"$2=$3"~g "${file}" > "$1" || rc=$?
-  # When the redirect succeeded but sed failed, the target has been truncated and must be restored from the untouched
-  # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The "-w" test tells
-  # that case apart from a redirect that never opened the target, where there is nothing to restore.
-  if [ "$rc" -ne 0 ] && [ -w "$1" ]; then
-    cp "${file}" "$1"
+  sed "$2" "${file}" > "$1" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    if [ -w "$1" ]; then
+      # The redirect succeeded but sed failed, so the target has been truncated and must be restored from the untouched
+      # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The restore is
+      # best-effort, since it can fail in turn (e.g. on a full filesystem), so that the copy below is always removed:
+      # for hibernate.cfg.xml it holds the database password.
+      cp "${file}" "$1" || echo >&2 "  ERROR: Could not restore [$1], which is now empty."
+    else
+      # The redirect could not even open the target, so there is nothing to restore. Report what to do about it: the
+      # shell's own message only names the file, and this is the expected failure when the file was left on a read-only
+      # root filesystem.
+      echo >&2 "  ERROR: Could not write to [$1]. When the container runs with a read-only root filesystem," \
+        "the XWiki configuration files must be bind-mounted individually, so that they are writable."
+    fi
   fi
   rm -f "${file}"
   return "$rc"
+}
+
+# $1 - the path to xwiki.[cfg|properties]
+# $2 - the setting/property to set
+# $3 - the new value
+function xwiki_replace() {
+  sed_in_place "$1" "s~\#\? \?$2 \?=.*~$2=$3~g"
 }
 
 # $1 - the setting/property to set
@@ -113,21 +130,9 @@ file_env() {
 # $2 - the replacement text
 # $3 - the file in which to do the search/replace
 function safesed {
-  # Same scheme as xwiki_replace: read from a temporary copy located on the permanent volume (the directory holding the
-  # target file is not writable with a read-only root filesystem) and write the result back with a truncating redirect
-  # so that the target file keeps its inode and file-level Docker volume mounts keep working.
-  local file expression rc=0
+  local expression
   expression="s/$(echo $1 | sed -e 's/\([[\/.*]\|\]\)/\\&/g')/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g"
-  file="$(mktemp /usr/local/xwiki/data/tmp/"$(basename "$3")".XXXXXX)"
-  cp "$3" "${file}"
-  sed "${expression}" "${file}" > "$3" || rc=$?
-  # Restore the truncated target from the untouched copy, for the same reason and with the same "-w" test as in
-  # xwiki_replace.
-  if [ "$rc" -ne 0 ] && [ -w "$3" ]; then
-    cp "${file}" "$3"
-  fi
-  rm -f "${file}"
-  return "$rc"
+  sed_in_place "$3" "${expression}"
 }
 
 # $1 - the config file name found in WEB-INF (e.g. "xwiki.cfg")

--- a/template/xwiki/docker-entrypoint.sh
+++ b/template/xwiki/docker-entrypoint.sh
@@ -48,10 +48,10 @@ function clean_temporary_directory() {
   mkdir -p /usr/local/xwiki/data/tmp
 }
 
-# \$1 - the path to xwiki.[cfg|properties]
-# \$2 - the setting/property to set
-# \$3 - the new value
-function xwiki_replace() {
+# Applies a sed expression to a file, in place.
+# \$1 - the file to modify
+# \$2 - the sed expression to apply
+function sed_in_place() {
   # Read from a temporary copy and write the result back with a truncating redirect, instead of using "sed -i". Two
   # constraints are at play:
   # * "sed -i" creates a temporary file and performs a rename, thus changing the inode of the initial file, which makes
@@ -59,19 +59,36 @@ function xwiki_replace() {
   #   inode.
   # * The temporary copy must not be created next to the target file, because the directory holding it is not writable
   #   when the container runs with a read-only root filesystem. It goes to the temporary directory on the permanent
-  #   volume, which is writable and emptied on every start (see clean_temporary_directory).
+  #   volume, which is writable and emptied on every start (see clean_temporary_directory). mktemp restricts it to its
+  #   owner, which matters because the copy of hibernate.cfg.xml holds the database password.
   local file rc=0
   file="\$(mktemp /usr/local/xwiki/data/tmp/"\$(basename "\$1")".XXXXXX)"
   cp "\$1" "\${file}"
-  sed s~"\\#\\? \\?\$2 \\?=.*"~"\$2=\$3"~g "\${file}" > "\$1" || rc=\$?
-  # When the redirect succeeded but sed failed, the target has been truncated and must be restored from the untouched
-  # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The "-w" test tells
-  # that case apart from a redirect that never opened the target, where there is nothing to restore.
-  if [ "\$rc" -ne 0 ] && [ -w "\$1" ]; then
-    cp "\${file}" "\$1"
+  sed "\$2" "\${file}" > "\$1" || rc=\$?
+  if [ "\$rc" -ne 0 ]; then
+    if [ -w "\$1" ]; then
+      # The redirect succeeded but sed failed, so the target has been truncated and must be restored from the untouched
+      # copy: for a bind-mounted configuration file, that target is the user's own file on the host. The restore is
+      # best-effort, since it can fail in turn (e.g. on a full filesystem), so that the copy below is always removed:
+      # for hibernate.cfg.xml it holds the database password.
+      cp "\${file}" "\$1" || echo >&2 "  ERROR: Could not restore [\$1], which is now empty."
+    else
+      # The redirect could not even open the target, so there is nothing to restore. Report what to do about it: the
+      # shell's own message only names the file, and this is the expected failure when the file was left on a read-only
+      # root filesystem.
+      echo >&2 "  ERROR: Could not write to [\$1]. When the container runs with a read-only root filesystem," \\
+        "the XWiki configuration files must be bind-mounted individually, so that they are writable."
+    fi
   fi
   rm -f "\${file}"
   return "\$rc"
+}
+
+# \$1 - the path to xwiki.[cfg|properties]
+# \$2 - the setting/property to set
+# \$3 - the new value
+function xwiki_replace() {
+  sed_in_place "\$1" "s~\\#\\? \\?\$2 \\?=.*~\$2=\$3~g"
 }
 
 # \$1 - the setting/property to set
@@ -113,21 +130,9 @@ file_env() {
 # \$2 - the replacement text
 # \$3 - the file in which to do the search/replace
 function safesed {
-  # Same scheme as xwiki_replace: read from a temporary copy located on the permanent volume (the directory holding the
-  # target file is not writable with a read-only root filesystem) and write the result back with a truncating redirect
-  # so that the target file keeps its inode and file-level Docker volume mounts keep working.
-  local file expression rc=0
+  local expression
   expression="s/\$(echo \$1 | sed -e 's/\\([[\\/.*]\\|\\]\\)/\\\\&/g')/\$(echo \$2 | sed -e 's/[\\/&]/\\\\&/g')/g"
-  file="\$(mktemp /usr/local/xwiki/data/tmp/"\$(basename "\$3")".XXXXXX)"
-  cp "\$3" "\${file}"
-  sed "\${expression}" "\${file}" > "\$3" || rc=\$?
-  # Restore the truncated target from the untouched copy, for the same reason and with the same "-w" test as in
-  # xwiki_replace.
-  if [ "\$rc" -ne 0 ] && [ -w "\$3" ]; then
-    cp "\${file}" "\$3"
-  fi
-  rm -f "\${file}"
-  return "\$rc"
+  sed_in_place "\$3" "\${expression}"
 }
 
 # \$1 - the config file name found in WEB-INF (e.g. "xwiki.cfg")


### PR DESCRIPTION
Follow-up to #94, on the same issue: [XDOCKER-417](https://jira.xwiki.org/browse/XDOCKER-417).

`xwiki_replace` and `safesed` both carried the same in-place sed body (temporary copy on the
permanent volume + truncating redirect + restore-on-failure). This extracts it into a single
`sed_in_place <file> <sed-expression>` helper and, in that one place, improves two things:

* **Actionable error when the target cannot be written.** With a read-only root filesystem and no
  bind-mounted configuration files, the redirect never opens the target and the shell's own message
  only names the file. It now also says what to do: the XWiki configuration files must be
  bind-mounted individually so that they are writable.
* **The temporary copy is always removed.** The restore of a truncated target is now best-effort
  (`cp … || echo >&2 …`), so `set -e` no longer aborts the function before its `rm -f`. Previously a
  restore that failed in turn (e.g. a full filesystem) left the temporary copy of
  `hibernate.cfg.xml` — which holds the database password — on the permanent volume. The start still
  fails; only the cleanup is now guaranteed.

The `mktemp`-restricted permissions of that copy are now explained in a comment, since they matter
for exactly that reason.

No behaviour change on the success path: the sed expressions and their delimiters are identical to
before.

## Testing

* `./gradlew` regenerated the 12 variants and leaves no diff (CI-safe); `bash -n` clean on all of
  them; no line over 120 characters.
* Runtime, on `18/postgres-tomcat`: a test image built from `xwiki:18.5.0-postgres-tomcat` plus this
  entry point, run against a `postgres:18` container.
  * **Normal start, writable root filesystem** — `hibernate.cfg.xml` gets the JDBC URL, user and
    password, `xwiki.cfg` gets `xwiki.webapppath=`, `xwiki.properties` gets
    `environment.permanentDirectory` and `openoffice.autoStart`; no placeholder left, no temporary
    copy left, no error.
  * **Read-only root filesystem with the documented mounts** — XWiki serves (HTTP 302 on `/`),
    LibreOffice starts, the three bind-mounted files are rewritten in place, and the only read-only
    line in the log is the intended `.first_start_completed` marker warning.
  * **Read-only root filesystem without bind-mounted configuration files** — exits 1 and prints the
    new error message; the temporary directory on the permanent volume is left empty.
  * **Restart under a read-only root filesystem** (the marker cannot be written, so `configure()`
    re-runs) — idempotent: the three configuration files are byte-identical afterwards and XWiki
    serves again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
