### PR TITLE
XDOCKER-421: The Docker image fails to build without BuildKit because TARGETARCH is empty

### DIFF
--- a/16/mariadb-tomcat/Dockerfile
+++ b/16/mariadb-tomcat/Dockerfile
@@ -72,18 +72,21 @@ RUN apt-get update && \
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
 # Docker-based test framework) and verify its sha256. Since the official image is built for both amd64 and arm64, we
-# select the download matching the target architecture (provided automatically by Docker's TARGETARCH build argument)
-# and its sha256. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki (through
-# JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is needed.
-ARG TARGETARCH
+# select the download matching the architecture and its sha256. The architecture is read from the image itself with
+# dpkg --print-architecture rather than from Docker's TARGETARCH build argument, because TARGETARCH is only set
+# automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
+# would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
+# (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
+# needed.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN case "$TARGETARCH" in \
+RUN LO_ARCH="$(dpkg --print-architecture)" && \
+  case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
-    *) echo "Unsupported target architecture [$TARGETARCH] for the LibreOffice installation" >&2; exit 1 ;; \
+    *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
   curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \

--- a/16/mysql-tomcat/Dockerfile
+++ b/16/mysql-tomcat/Dockerfile
@@ -72,18 +72,21 @@ RUN apt-get update && \
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
 # Docker-based test framework) and verify its sha256. Since the official image is built for both amd64 and arm64, we
-# select the download matching the target architecture (provided automatically by Docker's TARGETARCH build argument)
-# and its sha256. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki (through
-# JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is needed.
-ARG TARGETARCH
+# select the download matching the architecture and its sha256. The architecture is read from the image itself with
+# dpkg --print-architecture rather than from Docker's TARGETARCH build argument, because TARGETARCH is only set
+# automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
+# would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
+# (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
+# needed.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN case "$TARGETARCH" in \
+RUN LO_ARCH="$(dpkg --print-architecture)" && \
+  case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
-    *) echo "Unsupported target architecture [$TARGETARCH] for the LibreOffice installation" >&2; exit 1 ;; \
+    *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
   curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \

--- a/16/postgres-tomcat/Dockerfile
+++ b/16/postgres-tomcat/Dockerfile
@@ -72,18 +72,21 @@ RUN apt-get update && \
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
 # Docker-based test framework) and verify its sha256. Since the official image is built for both amd64 and arm64, we
-# select the download matching the target architecture (provided automatically by Docker's TARGETARCH build argument)
-# and its sha256. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki (through
-# JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is needed.
-ARG TARGETARCH
+# select the download matching the architecture and its sha256. The architecture is read from the image itself with
+# dpkg --print-architecture rather than from Docker's TARGETARCH build argument, because TARGETARCH is only set
+# automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
+# would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
+# (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
+# needed.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN case "$TARGETARCH" in \
+RUN LO_ARCH="$(dpkg --print-architecture)" && \
+  case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
-    *) echo "Unsupported target architecture [$TARGETARCH] for the LibreOffice installation" >&2; exit 1 ;; \
+    *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
   curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \

--- a/17/mariadb-tomcat/Dockerfile
+++ b/17/mariadb-tomcat/Dockerfile
@@ -72,18 +72,21 @@ RUN apt-get update && \
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
 # Docker-based test framework) and verify its sha256. Since the official image is built for both amd64 and arm64, we
-# select the download matching the target architecture (provided automatically by Docker's TARGETARCH build argument)
-# and its sha256. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki (through
-# JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is needed.
-ARG TARGETARCH
+# select the download matching the architecture and its sha256. The architecture is read from the image itself with
+# dpkg --print-architecture rather than from Docker's TARGETARCH build argument, because TARGETARCH is only set
+# automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
+# would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
+# (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
+# needed.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN case "$TARGETARCH" in \
+RUN LO_ARCH="$(dpkg --print-architecture)" && \
+  case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
-    *) echo "Unsupported target architecture [$TARGETARCH] for the LibreOffice installation" >&2; exit 1 ;; \
+    *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
   curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \

--- a/17/mysql-tomcat/Dockerfile
+++ b/17/mysql-tomcat/Dockerfile
@@ -72,18 +72,21 @@ RUN apt-get update && \
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
 # Docker-based test framework) and verify its sha256. Since the official image is built for both amd64 and arm64, we
-# select the download matching the target architecture (provided automatically by Docker's TARGETARCH build argument)
-# and its sha256. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki (through
-# JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is needed.
-ARG TARGETARCH
+# select the download matching the architecture and its sha256. The architecture is read from the image itself with
+# dpkg --print-architecture rather than from Docker's TARGETARCH build argument, because TARGETARCH is only set
+# automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
+# would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
+# (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
+# needed.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN case "$TARGETARCH" in \
+RUN LO_ARCH="$(dpkg --print-architecture)" && \
+  case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
-    *) echo "Unsupported target architecture [$TARGETARCH] for the LibreOffice installation" >&2; exit 1 ;; \
+    *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
   curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \

--- a/17/postgres-tomcat/Dockerfile
+++ b/17/postgres-tomcat/Dockerfile
@@ -72,18 +72,21 @@ RUN apt-get update && \
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
 # Docker-based test framework) and verify its sha256. Since the official image is built for both amd64 and arm64, we
-# select the download matching the target architecture (provided automatically by Docker's TARGETARCH build argument)
-# and its sha256. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki (through
-# JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is needed.
-ARG TARGETARCH
+# select the download matching the architecture and its sha256. The architecture is read from the image itself with
+# dpkg --print-architecture rather than from Docker's TARGETARCH build argument, because TARGETARCH is only set
+# automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
+# would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
+# (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
+# needed.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN case "$TARGETARCH" in \
+RUN LO_ARCH="$(dpkg --print-architecture)" && \
+  case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
-    *) echo "Unsupported target architecture [$TARGETARCH] for the LibreOffice installation" >&2; exit 1 ;; \
+    *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
   curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \

--- a/18.4/mariadb-tomcat/Dockerfile
+++ b/18.4/mariadb-tomcat/Dockerfile
@@ -72,18 +72,21 @@ RUN apt-get update && \
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
 # Docker-based test framework) and verify its sha256. Since the official image is built for both amd64 and arm64, we
-# select the download matching the target architecture (provided automatically by Docker's TARGETARCH build argument)
-# and its sha256. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki (through
-# JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is needed.
-ARG TARGETARCH
+# select the download matching the architecture and its sha256. The architecture is read from the image itself with
+# dpkg --print-architecture rather than from Docker's TARGETARCH build argument, because TARGETARCH is only set
+# automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
+# would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
+# (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
+# needed.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN case "$TARGETARCH" in \
+RUN LO_ARCH="$(dpkg --print-architecture)" && \
+  case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
-    *) echo "Unsupported target architecture [$TARGETARCH] for the LibreOffice installation" >&2; exit 1 ;; \
+    *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
   curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \

--- a/18.4/mysql-tomcat/Dockerfile
+++ b/18.4/mysql-tomcat/Dockerfile
@@ -72,18 +72,21 @@ RUN apt-get update && \
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
 # Docker-based test framework) and verify its sha256. Since the official image is built for both amd64 and arm64, we
-# select the download matching the target architecture (provided automatically by Docker's TARGETARCH build argument)
-# and its sha256. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki (through
-# JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is needed.
-ARG TARGETARCH
+# select the download matching the architecture and its sha256. The architecture is read from the image itself with
+# dpkg --print-architecture rather than from Docker's TARGETARCH build argument, because TARGETARCH is only set
+# automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
+# would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
+# (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
+# needed.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN case "$TARGETARCH" in \
+RUN LO_ARCH="$(dpkg --print-architecture)" && \
+  case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
-    *) echo "Unsupported target architecture [$TARGETARCH] for the LibreOffice installation" >&2; exit 1 ;; \
+    *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
   curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \

--- a/18.4/postgres-tomcat/Dockerfile
+++ b/18.4/postgres-tomcat/Dockerfile
@@ -72,18 +72,21 @@ RUN apt-get update && \
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
 # Docker-based test framework) and verify its sha256. Since the official image is built for both amd64 and arm64, we
-# select the download matching the target architecture (provided automatically by Docker's TARGETARCH build argument)
-# and its sha256. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki (through
-# JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is needed.
-ARG TARGETARCH
+# select the download matching the architecture and its sha256. The architecture is read from the image itself with
+# dpkg --print-architecture rather than from Docker's TARGETARCH build argument, because TARGETARCH is only set
+# automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
+# would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
+# (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
+# needed.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN case "$TARGETARCH" in \
+RUN LO_ARCH="$(dpkg --print-architecture)" && \
+  case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
-    *) echo "Unsupported target architecture [$TARGETARCH] for the LibreOffice installation" >&2; exit 1 ;; \
+    *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
   curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \

--- a/18/mariadb-tomcat/Dockerfile
+++ b/18/mariadb-tomcat/Dockerfile
@@ -72,18 +72,21 @@ RUN apt-get update && \
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
 # Docker-based test framework) and verify its sha256. Since the official image is built for both amd64 and arm64, we
-# select the download matching the target architecture (provided automatically by Docker's TARGETARCH build argument)
-# and its sha256. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki (through
-# JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is needed.
-ARG TARGETARCH
+# select the download matching the architecture and its sha256. The architecture is read from the image itself with
+# dpkg --print-architecture rather than from Docker's TARGETARCH build argument, because TARGETARCH is only set
+# automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
+# would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
+# (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
+# needed.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN case "$TARGETARCH" in \
+RUN LO_ARCH="$(dpkg --print-architecture)" && \
+  case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
-    *) echo "Unsupported target architecture [$TARGETARCH] for the LibreOffice installation" >&2; exit 1 ;; \
+    *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
   curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \

--- a/18/mysql-tomcat/Dockerfile
+++ b/18/mysql-tomcat/Dockerfile
@@ -72,18 +72,21 @@ RUN apt-get update && \
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
 # Docker-based test framework) and verify its sha256. Since the official image is built for both amd64 and arm64, we
-# select the download matching the target architecture (provided automatically by Docker's TARGETARCH build argument)
-# and its sha256. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki (through
-# JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is needed.
-ARG TARGETARCH
+# select the download matching the architecture and its sha256. The architecture is read from the image itself with
+# dpkg --print-architecture rather than from Docker's TARGETARCH build argument, because TARGETARCH is only set
+# automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
+# would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
+# (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
+# needed.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN case "$TARGETARCH" in \
+RUN LO_ARCH="$(dpkg --print-architecture)" && \
+  case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
-    *) echo "Unsupported target architecture [$TARGETARCH] for the LibreOffice installation" >&2; exit 1 ;; \
+    *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
   curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \

--- a/18/postgres-tomcat/Dockerfile
+++ b/18/postgres-tomcat/Dockerfile
@@ -72,18 +72,21 @@ RUN apt-get update && \
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
 # Docker-based test framework) and verify its sha256. Since the official image is built for both amd64 and arm64, we
-# select the download matching the target architecture (provided automatically by Docker's TARGETARCH build argument)
-# and its sha256. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki (through
-# JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is needed.
-ARG TARGETARCH
+# select the download matching the architecture and its sha256. The architecture is read from the image itself with
+# dpkg --print-architecture rather than from Docker's TARGETARCH build argument, because TARGETARCH is only set
+# automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
+# would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
+# (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
+# needed.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN case "$TARGETARCH" in \
+RUN LO_ARCH="$(dpkg --print-architecture)" && \
+  case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
-    *) echo "Unsupported target architecture [$TARGETARCH] for the LibreOffice installation" >&2; exit 1 ;; \
+    *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
   curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -72,18 +72,21 @@ RUN apt-get update && \\
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
 # Docker-based test framework) and verify its sha256. Since the official image is built for both amd64 and arm64, we
-# select the download matching the target architecture (provided automatically by Docker's TARGETARCH build argument)
-# and its sha256. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki (through
-# JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is needed.
-ARG TARGETARCH
+# select the download matching the architecture and its sha256. The architecture is read from the image itself with
+# dpkg --print-architecture rather than from Docker's TARGETARCH build argument, because TARGETARCH is only set
+# automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
+# would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
+# (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
+# needed.
 ENV LIBREOFFICE_VERSION="$libreofficeVersion"
 ENV LIBREOFFICE_SHA256_AMD64="$libreofficeSha256Amd64"
 ENV LIBREOFFICE_SHA256_ARM64="$libreofficeSha256Arm64"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/\${LIBREOFFICE_VERSION}/deb"
-RUN case "\$TARGETARCH" in \\
+RUN LO_ARCH="\$(dpkg --print-architecture)" && \\
+  case "\$LO_ARCH" in \\
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=\$LIBREOFFICE_SHA256_AMD64 ;; \\
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=\$LIBREOFFICE_SHA256_ARM64 ;; \\
-    *) echo "Unsupported target architecture [\$TARGETARCH] for the LibreOffice installation" >&2; exit 1 ;; \\
+    *) echo "Unsupported architecture [\$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \\
   esac && \\
   LO_ARCHIVE="LibreOffice_\${LIBREOFFICE_VERSION}_Linux_\${LO_ARCH_FILE}_deb.tar.gz" && \\
   curl -fSL "\${LIBREOFFICE_URL_PREFIX}/\${LO_ARCH_DIR}/\${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \\


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XDOCKER-421

## Problem

The Docker Official Images build of XWiki 18.6.0 failed on all three `18-*` variants:

```
Step 14/33 : RUN case "$TARGETARCH" in     amd64) ...
Unsupported target architecture [] for the LibreOffice installation
```

`TARGETARCH` is populated automatically only by BuildKit. The Docker Official Images infrastructure
builds with the classic builder, where a bare `ARG TARGETARCH` expands to the empty string, so the
LibreOffice architecture selection fell into its error branch.

This went unnoticed because a local `docker build` enables BuildKit by default, and because our own CI
only runs `./gradlew` and never builds an image.

All twelve generated `Dockerfile`s carry the problem. Only the `18` ones failed so far, because the
other cycles are still published from commits predating the LibreOffice installation step — bumping
any of them would have failed the same way.

## Fix

Read the architecture from the image itself with `dpkg --print-architecture`, which is what Docker
Official Images recommends. Both builders report identical `amd64`/`arm64` values, so the selection
logic is unchanged, and the image now also builds for users who have BuildKit disabled.

## Testing

Reproduced and verified with the classic builder (`DOCKER_BUILDKIT=0`), which is what the Docker
Official Images infrastructure uses.

The two builders disagree only about `TARGETARCH`, and agree about `dpkg`:

| Builder | `$TARGETARCH` | `dpkg --print-architecture` |
| --- | --- | --- |
| classic (`DOCKER_BUILDKIT=0`) | `[]` | `arm64` |
| BuildKit | `arm64` | `arm64` |

* Before this change, `18/mysql-tomcat` under the classic builder fails with exactly the error seen in
  the Docker Official Images CI (`Unsupported target architecture []`).
* After this change, the same build completes. In the resulting image `/opt/libreoffice` correctly
  resolves to `/opt/libreoffice25.8` and `soffice --version` reports `LibreOffice 25.8.7.3`, the WAR is
  deployed as the ROOT webapp, and the MySQL JDBC driver is in place.

`./gradlew` was re-run so the twelve generated directories match the template.
