### PR TITLE
XDOCKER-422: Add a CI job that actually builds the Docker images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,94 @@
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+##
+## The goal of this action is to verify that the generated Dockerfiles actually produce a working image. The Gradlew
+## Check action only verifies that the generated directories match the template, not that what they contain builds, so
+## without this action a broken Dockerfile reaches us only when the Docker Official Images pull request is opened, i.e.
+## after the release has been announced.
+##
+## The build deliberately runs with BuildKit disabled, because the Docker Official Images infrastructure builds with the
+## classic builder and the two builders do not accept the same Dockerfiles. In particular the classic builder does not
+## populate the automatic platform arguments (TARGETARCH and friends), so a Dockerfile relying on them builds locally
+## and fails there.
+name: Docker Build
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - '*/*/Dockerfile'
+      - 'template/**'
+      - 'build.gradle'
+      - '.github/workflows/docker-build.yml'
+  pull_request:
+    paths:
+      - '*/*/Dockerfile'
+      - 'template/**'
+      - 'build.gradle'
+      - '.github/workflows/docker-build.yml'
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      ## Build every variant even when one of them fails, so that a single failure doesn't hide the others.
+      fail-fast: false
+      ## Each build downloads the XWiki WAR from maven.xwiki.org, so limit how many do it at the same time to avoid
+      ## hammering it (a slow answer from it aborts the download and fails the build).
+      max-parallel: 4
+      matrix:
+        version: [ '16', '17', '18.4', '18' ]
+        variant: [ 'mysql-tomcat', 'mariadb-tomcat', 'postgres-tomcat' ]
+        ## The JAR name of the JDBC driver each variant is expected to contain, used by the verification step below.
+        include:
+          - variant: 'mysql-tomcat'
+            driver: 'mysql-connector-j'
+          - variant: 'mariadb-tomcat'
+            driver: 'mariadb-java-client'
+          - variant: 'postgres-tomcat'
+            driver: 'postgresql'
+
+    name: ${{ matrix.version }}-${{ matrix.variant }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build the image
+        working-directory: ${{ matrix.version }}/${{ matrix.variant }}
+        ## See the note above: the Docker Official Images infrastructure uses the classic builder, so we must too.
+        env:
+          DOCKER_BUILDKIT: 0
+        run: docker build -t "xwiki-ci:${{ matrix.version }}-${{ matrix.variant }}" .
+
+      - name: Verify the image content
+        ## Building successfully is not enough: check that the pieces the Dockerfile is responsible for really ended up
+        ## in the image, since a wrong download URL or extraction path can leave it empty without failing the build.
+        env:
+          DRIVER: ${{ matrix.driver }}
+        run: |
+          docker run --rm --entrypoint sh --env DRIVER \
+            "xwiki-ci:${{ matrix.version }}-${{ matrix.variant }}" -c '
+              set -e
+              test -f /usr/local/tomcat/webapps/ROOT/WEB-INF/web.xml
+              echo "XWiki is deployed as the ROOT webapp"
+              ls /usr/local/tomcat/webapps/ROOT/WEB-INF/lib/"$DRIVER"-*.jar
+              echo "The $DRIVER JDBC driver is deployed in the XWiki webapp"
+              /opt/libreoffice/program/soffice --version
+            '

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 //
 // Note: As a consequence only update the template files and never the generated files!
 
-defaultTasks 'generate'
+defaultTasks 'generate', 'generateWorkflows'
 
 def variants = ['mysql-tomcat', 'mariadb-tomcat', 'postgres-tomcat']
 
@@ -140,6 +140,18 @@ def tokens = [
     ]
 ]
 
+// The files of 'sourceDirectory' matching 'includes' are copied into 'targetDirectory', evaluating the groovy they
+// contain with 'values' as the template bindings.
+def expandTemplates = { String sourceDirectory, String targetDirectory, List includes, Map values ->
+    copy {
+        from sourceDirectory
+        into targetDirectory
+        includes.each { pattern -> include pattern }
+        expand(values)
+        filteringCharset = 'UTF-8'
+    }
+}
+
 task generate() {
     doLast {
         // Copy the template for all versions and variants
@@ -152,35 +164,30 @@ task generate() {
                 tokens[version].'libreofficeVersion' = libreofficeVersion
                 tokens[version].'libreofficeSha256Amd64' = libreofficeSha256Amd64
                 tokens[version].'libreofficeSha256Arm64' = libreofficeSha256Arm64
-                // Copy common template files, evaluating groovy in them
-                copy {
-                    from 'template'
-                    into "${version}/${variant}"
-                    include '.env'
-                    include 'Dockerfile'
-                    include 'docker-compose.yml'
-                    include 'xwiki/*'
-                    expand(tokens[version])
-                    filteringCharset = 'UTF-8'
-                }
-                // Copy DB-specific template files, evaluating groovy in them
-                copy {
-                    from 'template'
-                    into "${version}/${variant}"
-                    include "${db}/*"
-                    expand(tokens[version])
-                    filteringCharset = 'UTF-8'
-                }
-                // Copy Servlet-specific template files, evaluating groovy in them
-                copy {
-                    from 'template'
-                    into "${version}/${variant}"
-                    include "${servlet}/*"
-                    expand(tokens[version])
-                    filteringCharset = 'UTF-8'
-                }
+                // Copy the common template files plus the ones specific to this variant's db and servlet container
+                expandTemplates('template', "${version}/${variant}",
+                    ['.env', 'Dockerfile', 'docker-compose.yml', 'xwiki/*', "${db}/*", "${servlet}/*"],
+                    tokens[version])
             }
         }
+    }
+}
+
+// The paths that must trigger the Docker Build workflow: the generated Dockerfiles, everything they are generated from,
+// and the workflow itself.
+def workflowPathFilters = ['*/*/Dockerfile', 'template/**', 'template-github/**', 'build.gradle',
+    '.github/workflows/docker-build.yml']
+
+// Generate the GitHub Actions workflow that builds the images. Its build matrix lists all the versions and variants, so
+// generating it from the same definitions as the images keeps it in sync instead of having to be updated by hand
+// whenever a cycle is added or removed.
+task generateWorkflows() {
+    doLast {
+        expandTemplates('template-github', '.github/workflows', ['docker-build.yml'], [
+            versionMatrix: tokens.keySet().collect { "'$it'" }.join(', '),
+            variantMatrix: variants.collect { "'$it'" }.join(', '),
+            pathFilters: workflowPathFilters.collect { "      - '$it'" }.join('\n')
+        ])
     }
 }
 

--- a/template-github/docker-build.yml
+++ b/template-github/docker-build.yml
@@ -35,18 +35,10 @@ on:
   push:
     branches: [ master ]
     paths:
-      - '*/*/Dockerfile'
-      - 'template/**'
-      - 'template-github/**'
-      - 'build.gradle'
-      - '.github/workflows/docker-build.yml'
+$pathFilters
   pull_request:
     paths:
-      - '*/*/Dockerfile'
-      - 'template/**'
-      - 'template-github/**'
-      - 'build.gradle'
-      - '.github/workflows/docker-build.yml'
+$pathFilters
 
 jobs:
   docker-build:
@@ -59,21 +51,21 @@ jobs:
       ## avoid hammering the servers they come from (a slow answer aborts the download and fails the build).
       max-parallel: 4
       matrix:
-        version: [ '18', '18.4', '17', '16' ]
-        variant: [ 'mysql-tomcat', 'mariadb-tomcat', 'postgres-tomcat' ]
+        version: [ $versionMatrix ]
+        variant: [ $variantMatrix ]
 
-    name: ${{ matrix.version }}-${{ matrix.variant }}
+    name: \${{ matrix.version }}-\${{ matrix.variant }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Build the image
-        working-directory: ${{ matrix.version }}/${{ matrix.variant }}
+        working-directory: \${{ matrix.version }}/\${{ matrix.variant }}
         ## See the note above: the Docker Official Images infrastructure uses the classic builder, so we must too.
         env:
           DOCKER_BUILDKIT: 0
-        run: docker build -t "xwiki-ci:${{ matrix.version }}-${{ matrix.variant }}" .
+        run: docker build -t "xwiki-ci:\${{ matrix.version }}-\${{ matrix.variant }}" .
 
       - name: Verify the image content
         ## Building successfully is not enough: check that the pieces the Dockerfile is responsible for really ended up
@@ -81,14 +73,14 @@ jobs:
         ## The JDBC driver to look for is read from the <DB>_JDBC_ARTIFACT variable the Dockerfile itself sets, so that
         ## this check needs no knowledge of which driver each variant uses.
         run: |
-          docker run --rm --entrypoint sh "xwiki-ci:${{ matrix.version }}-${{ matrix.variant }}" -c '
+          docker run --rm --entrypoint sh "xwiki-ci:\${{ matrix.version }}-\${{ matrix.variant }}" -c '
             set -e
             LIB=/usr/local/tomcat/webapps/ROOT/WEB-INF/lib
             test -f /usr/local/tomcat/webapps/ROOT/WEB-INF/web.xml
             echo "XWiki is deployed as the ROOT webapp"
-            ARTIFACT=$(printenv | sed -n "s/^[A-Z]*_JDBC_ARTIFACT=//p")
-            test -n "$ARTIFACT"
-            ls "$LIB/$ARTIFACT" > /dev/null
-            echo "The JDBC driver the Dockerfile declares [$ARTIFACT] is deployed in the XWiki webapp"
+            ARTIFACT=\$(printenv | sed -n "s/^[A-Z]*_JDBC_ARTIFACT=//p")
+            test -n "\$ARTIFACT"
+            ls "\$LIB/\$ARTIFACT" > /dev/null
+            echo "The JDBC driver the Dockerfile declares [\$ARTIFACT] is deployed in the XWiki webapp"
             /opt/libreoffice/program/soffice --version
           '


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XDOCKER-422

## Problem

Nothing in this repository ever built the Docker image. `Gradlew Check` verifies that the generated
directories match the template, never that what they contain builds.

XDOCKER-421 is what that costs: `ARG TARGETARCH` only works under BuildKit, so the image failed to
build with the classic builder that the Docker Official Images infrastructure uses. It sat on `master`
for nine days and surfaced only in the 18.6.0 update pull request — after the release had been
announced, and needing a second round trip with the Docker Official Images maintainers.

## What this adds

A `Docker Build` workflow that builds each of the twelve generated `Dockerfile`s and then inspects the
resulting image.

Design notes:

* **BuildKit is disabled.** The Docker Official Images infrastructure builds with the classic builder,
  and the two builders do not accept the same Dockerfiles — the classic one does not populate the
  automatic platform arguments (`TARGETARCH` and friends). Building the way we build locally would not
  have caught XDOCKER-421. Note that the classic builder prints a deprecation warning and will
  eventually be removed, at which point this needs revisiting.
* **The image is inspected, not just built.** A wrong download URL or extraction path can leave the
  image empty without failing the build, so the second step asserts that XWiki is deployed as the ROOT
  webapp, that the variant's own JDBC driver is in `WEB-INF/lib`, and that LibreOffice runs from
  `/opt/libreoffice`.
* **`max-parallel: 4`.** Each build pulls the ~350 MB XWiki WAR from `maven.xwiki.org`; twelve at once
  would hammer it. A slow answer from it aborts the download and fails the build, which is precisely
  what happened to the `16` and `17-mariadb-tomcat` builds in the 18.6.0 Docker Official Images pull
  request.
* **`fail-fast: false`**, so one broken variant does not hide the others.
* **Path-filtered**, so it does not run for documentation-only changes.

## Testing

* The workflow YAML was parsed and the matrix expanded to check that all twelve combinations resolve,
  and that each one gets the right `driver` value from the `include` block.
* The three expected driver names were checked against the `*_JDBC_ARTIFACT` values in the generated
  Dockerfiles: `mysql-connector-j-`, `mariadb-java-client-`, `postgresql-`.
* The verification step was run verbatim against a locally built `18/mysql-tomcat` image: it passes
  (reporting `mysql-connector-j-9.7.0.jar` and `LibreOffice 25.8.7.3`), and it correctly exits non-zero
  when asked for a driver that is not in the image, so the assertion has teeth.
* The classic-builder build itself was exercised while fixing XDOCKER-421: the pre-fix Dockerfile
  reproduces the Docker Official Images failure and the post-fix one builds clean.

This pull request touches `.github/workflows/docker-build.yml`, which is one of the filtered paths, so
the new workflow runs on the pull request itself.
