### PR TITLE
XDOCKER-423: The image build fails on a transient network error while downloading its artifacts

### DIFF
--- a/16/mariadb-tomcat/Dockerfile
+++ b/16/mariadb-tomcat/Dockerfile
@@ -68,6 +68,14 @@ RUN apt-get update && \
     libxslt1.1 && \
   rm -rf /var/lib/apt/lists/*
 
+# Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
+# megabytes each) from servers that occasionally reset the connection or slow down to a crawl, and without retries the
+# first such hiccup aborts the whole build. Retrying does not weaken anything: every download is followed by a sha256
+# verification, which is what guarantees we got the expected bytes. --retry-all-errors is needed on top of --retry
+# because the failures seen in practice are mid-transfer ones (a reset connection, an HTTP/2 stream cancelled by the
+# server), which --retry alone does not consider retryable.
+ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30"
+
 # Install a controlled version of LibreOffice (the one XWiki supports and tests against, i.e. the LTS version) instead
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
@@ -89,7 +97,7 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
   echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
   mkdir -p /tmp/libreoffice && \
   tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
@@ -106,7 +114,7 @@ ENV XWIKI_DOWNLOAD_SHA256 53de2ca1583d8d4b17d858b2b81b615dd29b08dbac73eecd2d61de
 RUN rm -rf /usr/local/tomcat/webapps/* && \
   mkdir -p /usr/local/tomcat/temp && \
   mkdir -p /usr/local/xwiki/data && \
-  curl -fSL "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
   echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
   unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
   rm -f xwiki.war
@@ -119,7 +127,7 @@ ENV MARIADB_JDBC_SHA256="11e3bb5bbf8ef0e806ae4d6c5d5033fedf7262cc777f0190bde8a2f
 ENV MARIADB_JDBC_PREFIX="https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/${MARIADB_JDBC_VERSION}"
 ENV MARIADB_JDBC_ARTIFACT="mariadb-java-client-${MARIADB_JDBC_VERSION}.jar"
 ENV MARIADB_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${MARIADB_JDBC_ARTIFACT}"
-RUN curl -fSL "${MARIADB_JDBC_PREFIX}/${MARIADB_JDBC_ARTIFACT}" -o $MARIADB_JDBC_TARGET && \
+RUN curl $CURL_OPTIONS "${MARIADB_JDBC_PREFIX}/${MARIADB_JDBC_ARTIFACT}" -o $MARIADB_JDBC_TARGET && \
   echo "$MARIADB_JDBC_SHA256 $MARIADB_JDBC_TARGET" | sha256sum -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki

--- a/16/mysql-tomcat/Dockerfile
+++ b/16/mysql-tomcat/Dockerfile
@@ -68,6 +68,14 @@ RUN apt-get update && \
     libxslt1.1 && \
   rm -rf /var/lib/apt/lists/*
 
+# Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
+# megabytes each) from servers that occasionally reset the connection or slow down to a crawl, and without retries the
+# first such hiccup aborts the whole build. Retrying does not weaken anything: every download is followed by a sha256
+# verification, which is what guarantees we got the expected bytes. --retry-all-errors is needed on top of --retry
+# because the failures seen in practice are mid-transfer ones (a reset connection, an HTTP/2 stream cancelled by the
+# server), which --retry alone does not consider retryable.
+ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30"
+
 # Install a controlled version of LibreOffice (the one XWiki supports and tests against, i.e. the LTS version) instead
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
@@ -89,7 +97,7 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
   echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
   mkdir -p /tmp/libreoffice && \
   tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
@@ -106,7 +114,7 @@ ENV XWIKI_DOWNLOAD_SHA256 53de2ca1583d8d4b17d858b2b81b615dd29b08dbac73eecd2d61de
 RUN rm -rf /usr/local/tomcat/webapps/* && \
   mkdir -p /usr/local/tomcat/temp && \
   mkdir -p /usr/local/xwiki/data && \
-  curl -fSL "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
   echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
   unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
   rm -f xwiki.war
@@ -119,7 +127,7 @@ ENV MYSQL_JDBC_SHA256="0353648eaa1c91e0f4020c959abf756bc866ffd583df22ae6b6f6e0cb
 ENV MYSQL_JDBC_PREFIX="https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/${MYSQL_JDBC_VERSION}"
 ENV MYSQL_JDBC_ARTIFACT="mysql-connector-j-${MYSQL_JDBC_VERSION}.jar"
 ENV MYSQL_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${MYSQL_JDBC_ARTIFACT}"
-RUN curl -fSL "${MYSQL_JDBC_PREFIX}/${MYSQL_JDBC_ARTIFACT}" -o $MYSQL_JDBC_TARGET && \
+RUN curl $CURL_OPTIONS "${MYSQL_JDBC_PREFIX}/${MYSQL_JDBC_ARTIFACT}" -o $MYSQL_JDBC_TARGET && \
   echo "$MYSQL_JDBC_SHA256 $MYSQL_JDBC_TARGET" | sha256sum -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki

--- a/16/postgres-tomcat/Dockerfile
+++ b/16/postgres-tomcat/Dockerfile
@@ -68,6 +68,14 @@ RUN apt-get update && \
     libxslt1.1 && \
   rm -rf /var/lib/apt/lists/*
 
+# Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
+# megabytes each) from servers that occasionally reset the connection or slow down to a crawl, and without retries the
+# first such hiccup aborts the whole build. Retrying does not weaken anything: every download is followed by a sha256
+# verification, which is what guarantees we got the expected bytes. --retry-all-errors is needed on top of --retry
+# because the failures seen in practice are mid-transfer ones (a reset connection, an HTTP/2 stream cancelled by the
+# server), which --retry alone does not consider retryable.
+ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30"
+
 # Install a controlled version of LibreOffice (the one XWiki supports and tests against, i.e. the LTS version) instead
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
@@ -89,7 +97,7 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
   echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
   mkdir -p /tmp/libreoffice && \
   tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
@@ -106,7 +114,7 @@ ENV XWIKI_DOWNLOAD_SHA256 53de2ca1583d8d4b17d858b2b81b615dd29b08dbac73eecd2d61de
 RUN rm -rf /usr/local/tomcat/webapps/* && \
   mkdir -p /usr/local/tomcat/temp && \
   mkdir -p /usr/local/xwiki/data && \
-  curl -fSL "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
   echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
   unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
   rm -f xwiki.war
@@ -119,7 +127,7 @@ ENV POSTGRES_JDBC_SHA256="6e0e4cc2d8cae902084f8a2b18728b073a6fd9d1f87c9d8bff8f29
 ENV POSTGRES_JDBC_PREFIX="https://repo1.maven.org/maven2/org/postgresql/postgresql/${POSTGRES_JDBC_VERSION}"
 ENV POSTGRES_JDBC_ARTIFACT="postgresql-${POSTGRES_JDBC_VERSION}.jar"
 ENV POSTGRES_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${POSTGRES_JDBC_ARTIFACT}"
-RUN curl -fSL "${POSTGRES_JDBC_PREFIX}/${POSTGRES_JDBC_ARTIFACT}" -o $POSTGRES_JDBC_TARGET && \
+RUN curl $CURL_OPTIONS "${POSTGRES_JDBC_PREFIX}/${POSTGRES_JDBC_ARTIFACT}" -o $POSTGRES_JDBC_TARGET && \
   echo "$POSTGRES_JDBC_SHA256 $POSTGRES_JDBC_TARGET" | sha256sum -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki

--- a/17/mariadb-tomcat/Dockerfile
+++ b/17/mariadb-tomcat/Dockerfile
@@ -68,6 +68,14 @@ RUN apt-get update && \
     libxslt1.1 && \
   rm -rf /var/lib/apt/lists/*
 
+# Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
+# megabytes each) from servers that occasionally reset the connection or slow down to a crawl, and without retries the
+# first such hiccup aborts the whole build. Retrying does not weaken anything: every download is followed by a sha256
+# verification, which is what guarantees we got the expected bytes. --retry-all-errors is needed on top of --retry
+# because the failures seen in practice are mid-transfer ones (a reset connection, an HTTP/2 stream cancelled by the
+# server), which --retry alone does not consider retryable.
+ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30"
+
 # Install a controlled version of LibreOffice (the one XWiki supports and tests against, i.e. the LTS version) instead
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
@@ -89,7 +97,7 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
   echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
   mkdir -p /tmp/libreoffice && \
   tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
@@ -106,7 +114,7 @@ ENV XWIKI_DOWNLOAD_SHA256 f6e20373d9a3454d8dd54d9e9a0fbd6ed6006d44e97a56c2133dc7
 RUN rm -rf /usr/local/tomcat/webapps/* && \
   mkdir -p /usr/local/tomcat/temp && \
   mkdir -p /usr/local/xwiki/data && \
-  curl -fSL "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
   echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
   unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
   rm -f xwiki.war
@@ -119,7 +127,7 @@ ENV MARIADB_JDBC_SHA256="11e3bb5bbf8ef0e806ae4d6c5d5033fedf7262cc777f0190bde8a2f
 ENV MARIADB_JDBC_PREFIX="https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/${MARIADB_JDBC_VERSION}"
 ENV MARIADB_JDBC_ARTIFACT="mariadb-java-client-${MARIADB_JDBC_VERSION}.jar"
 ENV MARIADB_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${MARIADB_JDBC_ARTIFACT}"
-RUN curl -fSL "${MARIADB_JDBC_PREFIX}/${MARIADB_JDBC_ARTIFACT}" -o $MARIADB_JDBC_TARGET && \
+RUN curl $CURL_OPTIONS "${MARIADB_JDBC_PREFIX}/${MARIADB_JDBC_ARTIFACT}" -o $MARIADB_JDBC_TARGET && \
   echo "$MARIADB_JDBC_SHA256 $MARIADB_JDBC_TARGET" | sha256sum -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki

--- a/17/mysql-tomcat/Dockerfile
+++ b/17/mysql-tomcat/Dockerfile
@@ -68,6 +68,14 @@ RUN apt-get update && \
     libxslt1.1 && \
   rm -rf /var/lib/apt/lists/*
 
+# Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
+# megabytes each) from servers that occasionally reset the connection or slow down to a crawl, and without retries the
+# first such hiccup aborts the whole build. Retrying does not weaken anything: every download is followed by a sha256
+# verification, which is what guarantees we got the expected bytes. --retry-all-errors is needed on top of --retry
+# because the failures seen in practice are mid-transfer ones (a reset connection, an HTTP/2 stream cancelled by the
+# server), which --retry alone does not consider retryable.
+ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30"
+
 # Install a controlled version of LibreOffice (the one XWiki supports and tests against, i.e. the LTS version) instead
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
@@ -89,7 +97,7 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
   echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
   mkdir -p /tmp/libreoffice && \
   tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
@@ -106,7 +114,7 @@ ENV XWIKI_DOWNLOAD_SHA256 f6e20373d9a3454d8dd54d9e9a0fbd6ed6006d44e97a56c2133dc7
 RUN rm -rf /usr/local/tomcat/webapps/* && \
   mkdir -p /usr/local/tomcat/temp && \
   mkdir -p /usr/local/xwiki/data && \
-  curl -fSL "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
   echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
   unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
   rm -f xwiki.war
@@ -119,7 +127,7 @@ ENV MYSQL_JDBC_SHA256="0353648eaa1c91e0f4020c959abf756bc866ffd583df22ae6b6f6e0cb
 ENV MYSQL_JDBC_PREFIX="https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/${MYSQL_JDBC_VERSION}"
 ENV MYSQL_JDBC_ARTIFACT="mysql-connector-j-${MYSQL_JDBC_VERSION}.jar"
 ENV MYSQL_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${MYSQL_JDBC_ARTIFACT}"
-RUN curl -fSL "${MYSQL_JDBC_PREFIX}/${MYSQL_JDBC_ARTIFACT}" -o $MYSQL_JDBC_TARGET && \
+RUN curl $CURL_OPTIONS "${MYSQL_JDBC_PREFIX}/${MYSQL_JDBC_ARTIFACT}" -o $MYSQL_JDBC_TARGET && \
   echo "$MYSQL_JDBC_SHA256 $MYSQL_JDBC_TARGET" | sha256sum -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki

--- a/17/postgres-tomcat/Dockerfile
+++ b/17/postgres-tomcat/Dockerfile
@@ -68,6 +68,14 @@ RUN apt-get update && \
     libxslt1.1 && \
   rm -rf /var/lib/apt/lists/*
 
+# Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
+# megabytes each) from servers that occasionally reset the connection or slow down to a crawl, and without retries the
+# first such hiccup aborts the whole build. Retrying does not weaken anything: every download is followed by a sha256
+# verification, which is what guarantees we got the expected bytes. --retry-all-errors is needed on top of --retry
+# because the failures seen in practice are mid-transfer ones (a reset connection, an HTTP/2 stream cancelled by the
+# server), which --retry alone does not consider retryable.
+ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30"
+
 # Install a controlled version of LibreOffice (the one XWiki supports and tests against, i.e. the LTS version) instead
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
@@ -89,7 +97,7 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
   echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
   mkdir -p /tmp/libreoffice && \
   tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
@@ -106,7 +114,7 @@ ENV XWIKI_DOWNLOAD_SHA256 f6e20373d9a3454d8dd54d9e9a0fbd6ed6006d44e97a56c2133dc7
 RUN rm -rf /usr/local/tomcat/webapps/* && \
   mkdir -p /usr/local/tomcat/temp && \
   mkdir -p /usr/local/xwiki/data && \
-  curl -fSL "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
   echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
   unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
   rm -f xwiki.war
@@ -119,7 +127,7 @@ ENV POSTGRES_JDBC_SHA256="6e0e4cc2d8cae902084f8a2b18728b073a6fd9d1f87c9d8bff8f29
 ENV POSTGRES_JDBC_PREFIX="https://repo1.maven.org/maven2/org/postgresql/postgresql/${POSTGRES_JDBC_VERSION}"
 ENV POSTGRES_JDBC_ARTIFACT="postgresql-${POSTGRES_JDBC_VERSION}.jar"
 ENV POSTGRES_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${POSTGRES_JDBC_ARTIFACT}"
-RUN curl -fSL "${POSTGRES_JDBC_PREFIX}/${POSTGRES_JDBC_ARTIFACT}" -o $POSTGRES_JDBC_TARGET && \
+RUN curl $CURL_OPTIONS "${POSTGRES_JDBC_PREFIX}/${POSTGRES_JDBC_ARTIFACT}" -o $POSTGRES_JDBC_TARGET && \
   echo "$POSTGRES_JDBC_SHA256 $POSTGRES_JDBC_TARGET" | sha256sum -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki

--- a/18.4/mariadb-tomcat/Dockerfile
+++ b/18.4/mariadb-tomcat/Dockerfile
@@ -68,6 +68,14 @@ RUN apt-get update && \
     libxslt1.1 && \
   rm -rf /var/lib/apt/lists/*
 
+# Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
+# megabytes each) from servers that occasionally reset the connection or slow down to a crawl, and without retries the
+# first such hiccup aborts the whole build. Retrying does not weaken anything: every download is followed by a sha256
+# verification, which is what guarantees we got the expected bytes. --retry-all-errors is needed on top of --retry
+# because the failures seen in practice are mid-transfer ones (a reset connection, an HTTP/2 stream cancelled by the
+# server), which --retry alone does not consider retryable.
+ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30"
+
 # Install a controlled version of LibreOffice (the one XWiki supports and tests against, i.e. the LTS version) instead
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
@@ -89,7 +97,7 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
   echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
   mkdir -p /tmp/libreoffice && \
   tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
@@ -106,7 +114,7 @@ ENV XWIKI_DOWNLOAD_SHA256 79c8149d26271f6271379bfc449a42bf51d745ca74984c4a1ee89c
 RUN rm -rf /usr/local/tomcat/webapps/* && \
   mkdir -p /usr/local/tomcat/temp && \
   mkdir -p /usr/local/xwiki/data && \
-  curl -fSL "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
   echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
   unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
   rm -f xwiki.war
@@ -119,7 +127,7 @@ ENV MARIADB_JDBC_SHA256="11e3bb5bbf8ef0e806ae4d6c5d5033fedf7262cc777f0190bde8a2f
 ENV MARIADB_JDBC_PREFIX="https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/${MARIADB_JDBC_VERSION}"
 ENV MARIADB_JDBC_ARTIFACT="mariadb-java-client-${MARIADB_JDBC_VERSION}.jar"
 ENV MARIADB_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${MARIADB_JDBC_ARTIFACT}"
-RUN curl -fSL "${MARIADB_JDBC_PREFIX}/${MARIADB_JDBC_ARTIFACT}" -o $MARIADB_JDBC_TARGET && \
+RUN curl $CURL_OPTIONS "${MARIADB_JDBC_PREFIX}/${MARIADB_JDBC_ARTIFACT}" -o $MARIADB_JDBC_TARGET && \
   echo "$MARIADB_JDBC_SHA256 $MARIADB_JDBC_TARGET" | sha256sum -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki

--- a/18.4/mysql-tomcat/Dockerfile
+++ b/18.4/mysql-tomcat/Dockerfile
@@ -68,6 +68,14 @@ RUN apt-get update && \
     libxslt1.1 && \
   rm -rf /var/lib/apt/lists/*
 
+# Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
+# megabytes each) from servers that occasionally reset the connection or slow down to a crawl, and without retries the
+# first such hiccup aborts the whole build. Retrying does not weaken anything: every download is followed by a sha256
+# verification, which is what guarantees we got the expected bytes. --retry-all-errors is needed on top of --retry
+# because the failures seen in practice are mid-transfer ones (a reset connection, an HTTP/2 stream cancelled by the
+# server), which --retry alone does not consider retryable.
+ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30"
+
 # Install a controlled version of LibreOffice (the one XWiki supports and tests against, i.e. the LTS version) instead
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
@@ -89,7 +97,7 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
   echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
   mkdir -p /tmp/libreoffice && \
   tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
@@ -106,7 +114,7 @@ ENV XWIKI_DOWNLOAD_SHA256 79c8149d26271f6271379bfc449a42bf51d745ca74984c4a1ee89c
 RUN rm -rf /usr/local/tomcat/webapps/* && \
   mkdir -p /usr/local/tomcat/temp && \
   mkdir -p /usr/local/xwiki/data && \
-  curl -fSL "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
   echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
   unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
   rm -f xwiki.war
@@ -119,7 +127,7 @@ ENV MYSQL_JDBC_SHA256="0353648eaa1c91e0f4020c959abf756bc866ffd583df22ae6b6f6e0cb
 ENV MYSQL_JDBC_PREFIX="https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/${MYSQL_JDBC_VERSION}"
 ENV MYSQL_JDBC_ARTIFACT="mysql-connector-j-${MYSQL_JDBC_VERSION}.jar"
 ENV MYSQL_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${MYSQL_JDBC_ARTIFACT}"
-RUN curl -fSL "${MYSQL_JDBC_PREFIX}/${MYSQL_JDBC_ARTIFACT}" -o $MYSQL_JDBC_TARGET && \
+RUN curl $CURL_OPTIONS "${MYSQL_JDBC_PREFIX}/${MYSQL_JDBC_ARTIFACT}" -o $MYSQL_JDBC_TARGET && \
   echo "$MYSQL_JDBC_SHA256 $MYSQL_JDBC_TARGET" | sha256sum -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki

--- a/18.4/postgres-tomcat/Dockerfile
+++ b/18.4/postgres-tomcat/Dockerfile
@@ -68,6 +68,14 @@ RUN apt-get update && \
     libxslt1.1 && \
   rm -rf /var/lib/apt/lists/*
 
+# Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
+# megabytes each) from servers that occasionally reset the connection or slow down to a crawl, and without retries the
+# first such hiccup aborts the whole build. Retrying does not weaken anything: every download is followed by a sha256
+# verification, which is what guarantees we got the expected bytes. --retry-all-errors is needed on top of --retry
+# because the failures seen in practice are mid-transfer ones (a reset connection, an HTTP/2 stream cancelled by the
+# server), which --retry alone does not consider retryable.
+ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30"
+
 # Install a controlled version of LibreOffice (the one XWiki supports and tests against, i.e. the LTS version) instead
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
@@ -89,7 +97,7 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
   echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
   mkdir -p /tmp/libreoffice && \
   tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
@@ -106,7 +114,7 @@ ENV XWIKI_DOWNLOAD_SHA256 79c8149d26271f6271379bfc449a42bf51d745ca74984c4a1ee89c
 RUN rm -rf /usr/local/tomcat/webapps/* && \
   mkdir -p /usr/local/tomcat/temp && \
   mkdir -p /usr/local/xwiki/data && \
-  curl -fSL "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
   echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
   unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
   rm -f xwiki.war
@@ -119,7 +127,7 @@ ENV POSTGRES_JDBC_SHA256="6e0e4cc2d8cae902084f8a2b18728b073a6fd9d1f87c9d8bff8f29
 ENV POSTGRES_JDBC_PREFIX="https://repo1.maven.org/maven2/org/postgresql/postgresql/${POSTGRES_JDBC_VERSION}"
 ENV POSTGRES_JDBC_ARTIFACT="postgresql-${POSTGRES_JDBC_VERSION}.jar"
 ENV POSTGRES_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${POSTGRES_JDBC_ARTIFACT}"
-RUN curl -fSL "${POSTGRES_JDBC_PREFIX}/${POSTGRES_JDBC_ARTIFACT}" -o $POSTGRES_JDBC_TARGET && \
+RUN curl $CURL_OPTIONS "${POSTGRES_JDBC_PREFIX}/${POSTGRES_JDBC_ARTIFACT}" -o $POSTGRES_JDBC_TARGET && \
   echo "$POSTGRES_JDBC_SHA256 $POSTGRES_JDBC_TARGET" | sha256sum -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki

--- a/18/mariadb-tomcat/Dockerfile
+++ b/18/mariadb-tomcat/Dockerfile
@@ -68,6 +68,14 @@ RUN apt-get update && \
     libxslt1.1 && \
   rm -rf /var/lib/apt/lists/*
 
+# Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
+# megabytes each) from servers that occasionally reset the connection or slow down to a crawl, and without retries the
+# first such hiccup aborts the whole build. Retrying does not weaken anything: every download is followed by a sha256
+# verification, which is what guarantees we got the expected bytes. --retry-all-errors is needed on top of --retry
+# because the failures seen in practice are mid-transfer ones (a reset connection, an HTTP/2 stream cancelled by the
+# server), which --retry alone does not consider retryable.
+ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30"
+
 # Install a controlled version of LibreOffice (the one XWiki supports and tests against, i.e. the LTS version) instead
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
@@ -89,7 +97,7 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
   echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
   mkdir -p /tmp/libreoffice && \
   tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
@@ -106,7 +114,7 @@ ENV XWIKI_DOWNLOAD_SHA256 3f4d0210f57efd98be916379e18f4714c600312c22b288f20bbc0f
 RUN rm -rf /usr/local/tomcat/webapps/* && \
   mkdir -p /usr/local/tomcat/temp && \
   mkdir -p /usr/local/xwiki/data && \
-  curl -fSL "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
   echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
   unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
   rm -f xwiki.war
@@ -119,7 +127,7 @@ ENV MARIADB_JDBC_SHA256="11e3bb5bbf8ef0e806ae4d6c5d5033fedf7262cc777f0190bde8a2f
 ENV MARIADB_JDBC_PREFIX="https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/${MARIADB_JDBC_VERSION}"
 ENV MARIADB_JDBC_ARTIFACT="mariadb-java-client-${MARIADB_JDBC_VERSION}.jar"
 ENV MARIADB_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${MARIADB_JDBC_ARTIFACT}"
-RUN curl -fSL "${MARIADB_JDBC_PREFIX}/${MARIADB_JDBC_ARTIFACT}" -o $MARIADB_JDBC_TARGET && \
+RUN curl $CURL_OPTIONS "${MARIADB_JDBC_PREFIX}/${MARIADB_JDBC_ARTIFACT}" -o $MARIADB_JDBC_TARGET && \
   echo "$MARIADB_JDBC_SHA256 $MARIADB_JDBC_TARGET" | sha256sum -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki

--- a/18/mysql-tomcat/Dockerfile
+++ b/18/mysql-tomcat/Dockerfile
@@ -68,6 +68,14 @@ RUN apt-get update && \
     libxslt1.1 && \
   rm -rf /var/lib/apt/lists/*
 
+# Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
+# megabytes each) from servers that occasionally reset the connection or slow down to a crawl, and without retries the
+# first such hiccup aborts the whole build. Retrying does not weaken anything: every download is followed by a sha256
+# verification, which is what guarantees we got the expected bytes. --retry-all-errors is needed on top of --retry
+# because the failures seen in practice are mid-transfer ones (a reset connection, an HTTP/2 stream cancelled by the
+# server), which --retry alone does not consider retryable.
+ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30"
+
 # Install a controlled version of LibreOffice (the one XWiki supports and tests against, i.e. the LTS version) instead
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
@@ -89,7 +97,7 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
   echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
   mkdir -p /tmp/libreoffice && \
   tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
@@ -106,7 +114,7 @@ ENV XWIKI_DOWNLOAD_SHA256 3f4d0210f57efd98be916379e18f4714c600312c22b288f20bbc0f
 RUN rm -rf /usr/local/tomcat/webapps/* && \
   mkdir -p /usr/local/tomcat/temp && \
   mkdir -p /usr/local/xwiki/data && \
-  curl -fSL "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
   echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
   unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
   rm -f xwiki.war
@@ -119,7 +127,7 @@ ENV MYSQL_JDBC_SHA256="0353648eaa1c91e0f4020c959abf756bc866ffd583df22ae6b6f6e0cb
 ENV MYSQL_JDBC_PREFIX="https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/${MYSQL_JDBC_VERSION}"
 ENV MYSQL_JDBC_ARTIFACT="mysql-connector-j-${MYSQL_JDBC_VERSION}.jar"
 ENV MYSQL_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${MYSQL_JDBC_ARTIFACT}"
-RUN curl -fSL "${MYSQL_JDBC_PREFIX}/${MYSQL_JDBC_ARTIFACT}" -o $MYSQL_JDBC_TARGET && \
+RUN curl $CURL_OPTIONS "${MYSQL_JDBC_PREFIX}/${MYSQL_JDBC_ARTIFACT}" -o $MYSQL_JDBC_TARGET && \
   echo "$MYSQL_JDBC_SHA256 $MYSQL_JDBC_TARGET" | sha256sum -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki

--- a/18/postgres-tomcat/Dockerfile
+++ b/18/postgres-tomcat/Dockerfile
@@ -68,6 +68,14 @@ RUN apt-get update && \
     libxslt1.1 && \
   rm -rf /var/lib/apt/lists/*
 
+# Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
+# megabytes each) from servers that occasionally reset the connection or slow down to a crawl, and without retries the
+# first such hiccup aborts the whole build. Retrying does not weaken anything: every download is followed by a sha256
+# verification, which is what guarantees we got the expected bytes. --retry-all-errors is needed on top of --retry
+# because the failures seen in practice are mid-transfer ones (a reset connection, an HTTP/2 stream cancelled by the
+# server), which --retry alone does not consider retryable.
+ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30"
+
 # Install a controlled version of LibreOffice (the one XWiki supports and tests against, i.e. the LTS version) instead
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
@@ -89,7 +97,7 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
   esac && \
   LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl -fSL "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
   echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
   mkdir -p /tmp/libreoffice && \
   tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
@@ -106,7 +114,7 @@ ENV XWIKI_DOWNLOAD_SHA256 3f4d0210f57efd98be916379e18f4714c600312c22b288f20bbc0f
 RUN rm -rf /usr/local/tomcat/webapps/* && \
   mkdir -p /usr/local/tomcat/temp && \
   mkdir -p /usr/local/xwiki/data && \
-  curl -fSL "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
   echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
   unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
   rm -f xwiki.war
@@ -119,7 +127,7 @@ ENV POSTGRES_JDBC_SHA256="6e0e4cc2d8cae902084f8a2b18728b073a6fd9d1f87c9d8bff8f29
 ENV POSTGRES_JDBC_PREFIX="https://repo1.maven.org/maven2/org/postgresql/postgresql/${POSTGRES_JDBC_VERSION}"
 ENV POSTGRES_JDBC_ARTIFACT="postgresql-${POSTGRES_JDBC_VERSION}.jar"
 ENV POSTGRES_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${POSTGRES_JDBC_ARTIFACT}"
-RUN curl -fSL "${POSTGRES_JDBC_PREFIX}/${POSTGRES_JDBC_ARTIFACT}" -o $POSTGRES_JDBC_TARGET && \
+RUN curl $CURL_OPTIONS "${POSTGRES_JDBC_PREFIX}/${POSTGRES_JDBC_ARTIFACT}" -o $POSTGRES_JDBC_TARGET && \
   echo "$POSTGRES_JDBC_SHA256 $POSTGRES_JDBC_TARGET" | sha256sum -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -68,6 +68,14 @@ RUN apt-get update && \\
     libxslt1.1 && \\
   rm -rf /var/lib/apt/lists/*
 
+# Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
+# megabytes each) from servers that occasionally reset the connection or slow down to a crawl, and without retries the
+# first such hiccup aborts the whole build. Retrying does not weaken anything: every download is followed by a sha256
+# verification, which is what guarantees we got the expected bytes. --retry-all-errors is needed on top of --retry
+# because the failures seen in practice are mid-transfer ones (a reset connection, an HTTP/2 stream cancelled by the
+# server), which --retry alone does not consider retryable.
+ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30"
+
 # Install a controlled version of LibreOffice (the one XWiki supports and tests against, i.e. the LTS version) instead
 # of the version shipped by the base image's own distribution release, so that it doesn't drift from the tested
 # version. We take it from the Document Foundation download site (the same source and version used by the XWiki
@@ -89,7 +97,7 @@ RUN LO_ARCH="\$(dpkg --print-architecture)" && \\
     *) echo "Unsupported architecture [\$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \\
   esac && \\
   LO_ARCHIVE="LibreOffice_\${LIBREOFFICE_VERSION}_Linux_\${LO_ARCH_FILE}_deb.tar.gz" && \\
-  curl -fSL "\${LIBREOFFICE_URL_PREFIX}/\${LO_ARCH_DIR}/\${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \\
+  curl \$CURL_OPTIONS "\${LIBREOFFICE_URL_PREFIX}/\${LO_ARCH_DIR}/\${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \\
   echo "\$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \\
   mkdir -p /tmp/libreoffice && \\
   tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \\
@@ -106,7 +114,7 @@ ENV XWIKI_DOWNLOAD_SHA256 $xwikiSha256
 RUN rm -rf /usr/local/tomcat/webapps/* && \\
   mkdir -p /usr/local/tomcat/temp && \\
   mkdir -p /usr/local/xwiki/data && \\
-  curl -fSL "\${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-\${XWIKI_VERSION}.war" -o xwiki.war && \\
+  curl \$CURL_OPTIONS "\${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-\${XWIKI_VERSION}.war" -o xwiki.war && \\
   echo "\$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \\
   unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \\
   rm -f xwiki.war
@@ -121,7 +129,7 @@ if (db == 'mysql') {
   println "ENV MYSQL_JDBC_PREFIX=\"https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/\${MYSQL_JDBC_VERSION}\""
   println "ENV MYSQL_JDBC_ARTIFACT=\"mysql-connector-j-\${MYSQL_JDBC_VERSION}.jar\""
   println "ENV MYSQL_JDBC_TARGET=\"/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/\${MYSQL_JDBC_ARTIFACT}\""
-  println "RUN curl -fSL \"\${MYSQL_JDBC_PREFIX}/\${MYSQL_JDBC_ARTIFACT}\" -o \$MYSQL_JDBC_TARGET && \\"
+  println "RUN curl \$CURL_OPTIONS \"\${MYSQL_JDBC_PREFIX}/\${MYSQL_JDBC_ARTIFACT}\" -o \$MYSQL_JDBC_TARGET && \\"
   print "  echo \"\$MYSQL_JDBC_SHA256 \$MYSQL_JDBC_TARGET\" | sha256sum -c -"
 } else if (db == 'mariadb') {
   println "ENV MARIADB_JDBC_VERSION=\"$mariadbJDBCVersion\""
@@ -129,7 +137,7 @@ if (db == 'mysql') {
   println "ENV MARIADB_JDBC_PREFIX=\"https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/\${MARIADB_JDBC_VERSION}\""
   println "ENV MARIADB_JDBC_ARTIFACT=\"mariadb-java-client-\${MARIADB_JDBC_VERSION}.jar\""
   println "ENV MARIADB_JDBC_TARGET=\"/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/\${MARIADB_JDBC_ARTIFACT}\""
-  println "RUN curl -fSL \"\${MARIADB_JDBC_PREFIX}/\${MARIADB_JDBC_ARTIFACT}\" -o \$MARIADB_JDBC_TARGET && \\"
+  println "RUN curl \$CURL_OPTIONS \"\${MARIADB_JDBC_PREFIX}/\${MARIADB_JDBC_ARTIFACT}\" -o \$MARIADB_JDBC_TARGET && \\"
   print "  echo \"\$MARIADB_JDBC_SHA256 \$MARIADB_JDBC_TARGET\" | sha256sum -c -"
 } else if (db == 'postgres') {
   println "ENV POSTGRES_JDBC_VERSION=\"$postgresJDBCVersion\""
@@ -137,7 +145,8 @@ if (db == 'mysql') {
   println "ENV POSTGRES_JDBC_PREFIX=\"https://repo1.maven.org/maven2/org/postgresql/postgresql/\${POSTGRES_JDBC_VERSION}\""
   println "ENV POSTGRES_JDBC_ARTIFACT=\"postgresql-\${POSTGRES_JDBC_VERSION}.jar\""
   println "ENV POSTGRES_JDBC_TARGET=\"/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/\${POSTGRES_JDBC_ARTIFACT}\""
-  println "RUN curl -fSL \"\${POSTGRES_JDBC_PREFIX}/\${POSTGRES_JDBC_ARTIFACT}\" -o \$POSTGRES_JDBC_TARGET && \\"
+  println "RUN curl \$CURL_OPTIONS \"\${POSTGRES_JDBC_PREFIX}/\${POSTGRES_JDBC_ARTIFACT}\" " +
+    "-o \$POSTGRES_JDBC_TARGET && \\"
   print "  echo \"\$POSTGRES_JDBC_SHA256 \$POSTGRES_JDBC_TARGET\" | sha256sum -c -"
 } %>
 


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XDOCKER-423

## Problem

The `Dockerfile` downloads three large artifacts with a plain `curl -fSL` and no retry: the XWiki WAR
(~350 MB) from `maven.xwiki.org`, the LibreOffice archive (~350 MB) from
`download.documentfoundation.org`, and the JDBC driver from Maven Central. A single hiccup on any of
them aborts the whole build.

This happens regularly:

* In the Docker Official Images pull request updating the image to 18.6.0, the `16` and
  `17-mariadb-tomcat` builds failed with `curl: (92) HTTP/2 stream 1 was not closed cleanly: CANCEL`
  while downloading the XWiki WAR, after the transfer had slowed to 181 KB/s. The other variants
  downloading the very same WAR succeeded, so the artifact was fine — and re-downloading it since gives
  a clean ~40 MB/s transfer whose sha256 matches.
* Building the twelve variants in our own CI, two of them (`16-postgres-tomcat` and
  `18-postgres-tomcat`) failed with `curl: (35) Recv failure: Connection reset by peer` on the
  LibreOffice archive, while the other ten passed. That is a ~17% flake rate per run, which makes a
  twelve-variant build job nearly impossible to get fully green.

Each failure costs a manual re-run, and for the Docker Official Images builds it means asking their
maintainers to re-run.

## Fix

Let `curl` retry. `--retry-all-errors` is needed on top of `--retry` because the failures seen in
practice are mid-transfer ones (a reset connection, a cancelled HTTP/2 stream), which `--retry` alone
does not treat as retryable. Retrying does not weaken anything: every download is still followed by the
same sha256 verification, which is what guarantees we got the expected bytes.

The options are set once in a `CURL_OPTIONS` variable rather than repeated at each of the five download
sites.

## Testing

* Verified that `$CURL_OPTIONS` word-splits into real flags and that the retries actually happen: with
  a deliberately unreachable URL, curl reports `Problem (retrying all errors). Will retry in 1 seconds.
  3 retries`, counting down as expected.
* Checked that `--retry-all-errors` is supported by the curl in the images — all variants, including the
  Tomcat 9 based `16` cycle, ship curl 8.5.0, well past the 7.71 it needs.
* Built `18/postgres-tomcat` end to end with the classic builder (the Docker Official Images one): the
  build completes, `postgresql-42.7.13.jar` is deployed in the webapp and LibreOffice 25.8.7.3 runs.
  This variant also exercises the one template line that had to be wrapped to stay within 120 columns.
* `./gradlew` was re-run so the twelve generated directories match the template.
