### PR TITLE
XDOCKER-426: Harden the Dockerfile build steps

### DIFF
--- a/16/mariadb-tomcat/Dockerfile
+++ b/16/mariadb-tomcat/Dockerfile
@@ -50,7 +50,8 @@ LABEL org.opencontainers.image.licenses='LGPL-2.1'
 # true (no DISPLAY is set), so by default the JVM uses the headless backend (libawt_headless.so, no X11 deps) and the
 # problem does not appear; installing these libraries keeps image parsing working when a user forces non-headless mode
 # via -Djava.awt.headless=false or by setting a DISPLAY variable.
-RUN apt-get update && \
+RUN set -eux; \
+  apt-get update; \
   apt-get --no-install-recommends -y install \
     curl \
     unzip \
@@ -65,7 +66,7 @@ RUN apt-get update && \
     libx11-xcb1 \
     libnss3 \
     libxml2 \
-    libxslt1.1 && \
+    libxslt1.1; \
   rm -rf /var/lib/apt/lists/*
 
 # Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
@@ -85,24 +86,31 @@ ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-ti
 # automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
 # would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
 # (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
-# needed.
+# needed. The deb packages install into /opt/libreoffice<major>.<minor>, so the symlink target is derived from
+# LIBREOFFICE_VERSION by stripping its patch component rather than by globbing /opt. The -n flag of ln is what makes it
+# replace /opt/libreoffice itself: without it, ln dereferences an already-existing symlink to a directory and creates
+# the new link inside that directory instead. We then check that the symlink resolves to an actual soffice binary:
+# since it is the only thing making JODConverter find LibreOffice, an installation landing elsewhere must fail the
+# build rather than produce an image where office import/export silently doesn't work.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN LO_ARCH="$(dpkg --print-architecture)" && \
+RUN set -eux; \
+  LO_ARCH="$(dpkg --print-architecture)"; \
   case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
-  esac && \
-  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
-  echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
-  mkdir -p /tmp/libreoffice && \
-  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
-  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb && \
-  ln -fs $(ls -d /opt/libreoffice*) /opt/libreoffice && \
+  esac; \
+  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz"; \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz; \
+  echo "$LO_SHA256 */tmp/libreoffice.tar.gz" | sha256sum --strict -c -; \
+  mkdir -p /tmp/libreoffice; \
+  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz; \
+  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb; \
+  ln -fns "/opt/libreoffice${LIBREOFFICE_VERSION%.*}" /opt/libreoffice; \
+  test -x /opt/libreoffice/program/soffice; \
   rm -rf /tmp/libreoffice /tmp/libreoffice.tar.gz
 
 # Install XWiki as the ROOT webapp context in Tomcat
@@ -111,12 +119,13 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
 ENV XWIKI_VERSION="16.10.18"
 ENV XWIKI_URL_PREFIX "https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-distribution-war/${XWIKI_VERSION}"
 ENV XWIKI_DOWNLOAD_SHA256 53de2ca1583d8d4b17d858b2b81b615dd29b08dbac73eecd2d61deae7afee5bf
-RUN rm -rf /usr/local/tomcat/webapps/* && \
-  mkdir -p /usr/local/tomcat/temp && \
-  mkdir -p /usr/local/xwiki/data && \
-  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
-  echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
-  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
+RUN set -eux; \
+  rm -rf /usr/local/tomcat/webapps/*; \
+  mkdir -p /usr/local/tomcat/temp; \
+  mkdir -p /usr/local/xwiki/data; \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war; \
+  echo "$XWIKI_DOWNLOAD_SHA256 *xwiki.war" | sha256sum --strict -c -; \
+  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war; \
   rm -f xwiki.war
 
 # Copy the JDBC driver in the XWiki webapp
@@ -127,8 +136,9 @@ ENV MARIADB_JDBC_SHA256="11e3bb5bbf8ef0e806ae4d6c5d5033fedf7262cc777f0190bde8a2f
 ENV MARIADB_JDBC_PREFIX="https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/${MARIADB_JDBC_VERSION}"
 ENV MARIADB_JDBC_ARTIFACT="mariadb-java-client-${MARIADB_JDBC_VERSION}.jar"
 ENV MARIADB_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${MARIADB_JDBC_ARTIFACT}"
-RUN curl $CURL_OPTIONS "${MARIADB_JDBC_PREFIX}/${MARIADB_JDBC_ARTIFACT}" -o $MARIADB_JDBC_TARGET && \
-  echo "$MARIADB_JDBC_SHA256 $MARIADB_JDBC_TARGET" | sha256sum -c -
+RUN set -eux; \
+  curl $CURL_OPTIONS "${MARIADB_JDBC_PREFIX}/${MARIADB_JDBC_ARTIFACT}" -o $MARIADB_JDBC_TARGET; \
+  echo "$MARIADB_JDBC_SHA256 *$MARIADB_JDBC_TARGET" | sha256sum --strict -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki
 COPY tomcat/setenv.sh /usr/local/tomcat/bin/
@@ -142,11 +152,12 @@ COPY xwiki/hibernate.cfg.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cf
 # version-specific logger levels it defines: the appender definition is inserted right after the opening
 # <configuration> tag and its reference right after the existing "stdout" one.
 COPY xwiki/logback-filelog-appender.xml xwiki/logback-filelog-ref.xml /tmp/
-RUN LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml && \
+RUN set -eux; \
+  LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml; \
   sed -e '/<configuration/r /tmp/logback-filelog-appender.xml' \
       -e '/ref="stdout"/r /tmp/logback-filelog-ref.xml' \
-      "$LOGBACK" > "$LOGBACK.new" && \
-  mv "$LOGBACK.new" "$LOGBACK" && \
+      "$LOGBACK" > "$LOGBACK.new"; \
+  mv "$LOGBACK.new" "$LOGBACK"; \
   rm -f /tmp/logback-filelog-appender.xml /tmp/logback-filelog-ref.xml
 
 # Set a specific distribution id in XWiki for this docker packaging.

--- a/16/mysql-tomcat/Dockerfile
+++ b/16/mysql-tomcat/Dockerfile
@@ -50,7 +50,8 @@ LABEL org.opencontainers.image.licenses='LGPL-2.1'
 # true (no DISPLAY is set), so by default the JVM uses the headless backend (libawt_headless.so, no X11 deps) and the
 # problem does not appear; installing these libraries keeps image parsing working when a user forces non-headless mode
 # via -Djava.awt.headless=false or by setting a DISPLAY variable.
-RUN apt-get update && \
+RUN set -eux; \
+  apt-get update; \
   apt-get --no-install-recommends -y install \
     curl \
     unzip \
@@ -65,7 +66,7 @@ RUN apt-get update && \
     libx11-xcb1 \
     libnss3 \
     libxml2 \
-    libxslt1.1 && \
+    libxslt1.1; \
   rm -rf /var/lib/apt/lists/*
 
 # Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
@@ -85,24 +86,31 @@ ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-ti
 # automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
 # would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
 # (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
-# needed.
+# needed. The deb packages install into /opt/libreoffice<major>.<minor>, so the symlink target is derived from
+# LIBREOFFICE_VERSION by stripping its patch component rather than by globbing /opt. The -n flag of ln is what makes it
+# replace /opt/libreoffice itself: without it, ln dereferences an already-existing symlink to a directory and creates
+# the new link inside that directory instead. We then check that the symlink resolves to an actual soffice binary:
+# since it is the only thing making JODConverter find LibreOffice, an installation landing elsewhere must fail the
+# build rather than produce an image where office import/export silently doesn't work.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN LO_ARCH="$(dpkg --print-architecture)" && \
+RUN set -eux; \
+  LO_ARCH="$(dpkg --print-architecture)"; \
   case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
-  esac && \
-  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
-  echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
-  mkdir -p /tmp/libreoffice && \
-  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
-  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb && \
-  ln -fs $(ls -d /opt/libreoffice*) /opt/libreoffice && \
+  esac; \
+  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz"; \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz; \
+  echo "$LO_SHA256 */tmp/libreoffice.tar.gz" | sha256sum --strict -c -; \
+  mkdir -p /tmp/libreoffice; \
+  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz; \
+  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb; \
+  ln -fns "/opt/libreoffice${LIBREOFFICE_VERSION%.*}" /opt/libreoffice; \
+  test -x /opt/libreoffice/program/soffice; \
   rm -rf /tmp/libreoffice /tmp/libreoffice.tar.gz
 
 # Install XWiki as the ROOT webapp context in Tomcat
@@ -111,12 +119,13 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
 ENV XWIKI_VERSION="16.10.18"
 ENV XWIKI_URL_PREFIX "https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-distribution-war/${XWIKI_VERSION}"
 ENV XWIKI_DOWNLOAD_SHA256 53de2ca1583d8d4b17d858b2b81b615dd29b08dbac73eecd2d61deae7afee5bf
-RUN rm -rf /usr/local/tomcat/webapps/* && \
-  mkdir -p /usr/local/tomcat/temp && \
-  mkdir -p /usr/local/xwiki/data && \
-  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
-  echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
-  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
+RUN set -eux; \
+  rm -rf /usr/local/tomcat/webapps/*; \
+  mkdir -p /usr/local/tomcat/temp; \
+  mkdir -p /usr/local/xwiki/data; \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war; \
+  echo "$XWIKI_DOWNLOAD_SHA256 *xwiki.war" | sha256sum --strict -c -; \
+  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war; \
   rm -f xwiki.war
 
 # Copy the JDBC driver in the XWiki webapp
@@ -127,8 +136,9 @@ ENV MYSQL_JDBC_SHA256="0353648eaa1c91e0f4020c959abf756bc866ffd583df22ae6b6f6e0cb
 ENV MYSQL_JDBC_PREFIX="https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/${MYSQL_JDBC_VERSION}"
 ENV MYSQL_JDBC_ARTIFACT="mysql-connector-j-${MYSQL_JDBC_VERSION}.jar"
 ENV MYSQL_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${MYSQL_JDBC_ARTIFACT}"
-RUN curl $CURL_OPTIONS "${MYSQL_JDBC_PREFIX}/${MYSQL_JDBC_ARTIFACT}" -o $MYSQL_JDBC_TARGET && \
-  echo "$MYSQL_JDBC_SHA256 $MYSQL_JDBC_TARGET" | sha256sum -c -
+RUN set -eux; \
+  curl $CURL_OPTIONS "${MYSQL_JDBC_PREFIX}/${MYSQL_JDBC_ARTIFACT}" -o $MYSQL_JDBC_TARGET; \
+  echo "$MYSQL_JDBC_SHA256 *$MYSQL_JDBC_TARGET" | sha256sum --strict -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki
 COPY tomcat/setenv.sh /usr/local/tomcat/bin/
@@ -142,11 +152,12 @@ COPY xwiki/hibernate.cfg.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cf
 # version-specific logger levels it defines: the appender definition is inserted right after the opening
 # <configuration> tag and its reference right after the existing "stdout" one.
 COPY xwiki/logback-filelog-appender.xml xwiki/logback-filelog-ref.xml /tmp/
-RUN LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml && \
+RUN set -eux; \
+  LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml; \
   sed -e '/<configuration/r /tmp/logback-filelog-appender.xml' \
       -e '/ref="stdout"/r /tmp/logback-filelog-ref.xml' \
-      "$LOGBACK" > "$LOGBACK.new" && \
-  mv "$LOGBACK.new" "$LOGBACK" && \
+      "$LOGBACK" > "$LOGBACK.new"; \
+  mv "$LOGBACK.new" "$LOGBACK"; \
   rm -f /tmp/logback-filelog-appender.xml /tmp/logback-filelog-ref.xml
 
 # Set a specific distribution id in XWiki for this docker packaging.

--- a/16/postgres-tomcat/Dockerfile
+++ b/16/postgres-tomcat/Dockerfile
@@ -50,7 +50,8 @@ LABEL org.opencontainers.image.licenses='LGPL-2.1'
 # true (no DISPLAY is set), so by default the JVM uses the headless backend (libawt_headless.so, no X11 deps) and the
 # problem does not appear; installing these libraries keeps image parsing working when a user forces non-headless mode
 # via -Djava.awt.headless=false or by setting a DISPLAY variable.
-RUN apt-get update && \
+RUN set -eux; \
+  apt-get update; \
   apt-get --no-install-recommends -y install \
     curl \
     unzip \
@@ -65,7 +66,7 @@ RUN apt-get update && \
     libx11-xcb1 \
     libnss3 \
     libxml2 \
-    libxslt1.1 && \
+    libxslt1.1; \
   rm -rf /var/lib/apt/lists/*
 
 # Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
@@ -85,24 +86,31 @@ ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-ti
 # automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
 # would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
 # (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
-# needed.
+# needed. The deb packages install into /opt/libreoffice<major>.<minor>, so the symlink target is derived from
+# LIBREOFFICE_VERSION by stripping its patch component rather than by globbing /opt. The -n flag of ln is what makes it
+# replace /opt/libreoffice itself: without it, ln dereferences an already-existing symlink to a directory and creates
+# the new link inside that directory instead. We then check that the symlink resolves to an actual soffice binary:
+# since it is the only thing making JODConverter find LibreOffice, an installation landing elsewhere must fail the
+# build rather than produce an image where office import/export silently doesn't work.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN LO_ARCH="$(dpkg --print-architecture)" && \
+RUN set -eux; \
+  LO_ARCH="$(dpkg --print-architecture)"; \
   case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
-  esac && \
-  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
-  echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
-  mkdir -p /tmp/libreoffice && \
-  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
-  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb && \
-  ln -fs $(ls -d /opt/libreoffice*) /opt/libreoffice && \
+  esac; \
+  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz"; \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz; \
+  echo "$LO_SHA256 */tmp/libreoffice.tar.gz" | sha256sum --strict -c -; \
+  mkdir -p /tmp/libreoffice; \
+  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz; \
+  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb; \
+  ln -fns "/opt/libreoffice${LIBREOFFICE_VERSION%.*}" /opt/libreoffice; \
+  test -x /opt/libreoffice/program/soffice; \
   rm -rf /tmp/libreoffice /tmp/libreoffice.tar.gz
 
 # Install XWiki as the ROOT webapp context in Tomcat
@@ -111,12 +119,13 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
 ENV XWIKI_VERSION="16.10.18"
 ENV XWIKI_URL_PREFIX "https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-distribution-war/${XWIKI_VERSION}"
 ENV XWIKI_DOWNLOAD_SHA256 53de2ca1583d8d4b17d858b2b81b615dd29b08dbac73eecd2d61deae7afee5bf
-RUN rm -rf /usr/local/tomcat/webapps/* && \
-  mkdir -p /usr/local/tomcat/temp && \
-  mkdir -p /usr/local/xwiki/data && \
-  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
-  echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
-  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
+RUN set -eux; \
+  rm -rf /usr/local/tomcat/webapps/*; \
+  mkdir -p /usr/local/tomcat/temp; \
+  mkdir -p /usr/local/xwiki/data; \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war; \
+  echo "$XWIKI_DOWNLOAD_SHA256 *xwiki.war" | sha256sum --strict -c -; \
+  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war; \
   rm -f xwiki.war
 
 # Copy the JDBC driver in the XWiki webapp
@@ -127,8 +136,9 @@ ENV POSTGRES_JDBC_SHA256="6e0e4cc2d8cae902084f8a2b18728b073a6fd9d1f87c9d8bff8f29
 ENV POSTGRES_JDBC_PREFIX="https://repo1.maven.org/maven2/org/postgresql/postgresql/${POSTGRES_JDBC_VERSION}"
 ENV POSTGRES_JDBC_ARTIFACT="postgresql-${POSTGRES_JDBC_VERSION}.jar"
 ENV POSTGRES_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${POSTGRES_JDBC_ARTIFACT}"
-RUN curl $CURL_OPTIONS "${POSTGRES_JDBC_PREFIX}/${POSTGRES_JDBC_ARTIFACT}" -o $POSTGRES_JDBC_TARGET && \
-  echo "$POSTGRES_JDBC_SHA256 $POSTGRES_JDBC_TARGET" | sha256sum -c -
+RUN set -eux; \
+  curl $CURL_OPTIONS "${POSTGRES_JDBC_PREFIX}/${POSTGRES_JDBC_ARTIFACT}" -o $POSTGRES_JDBC_TARGET; \
+  echo "$POSTGRES_JDBC_SHA256 *$POSTGRES_JDBC_TARGET" | sha256sum --strict -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki
 COPY tomcat/setenv.sh /usr/local/tomcat/bin/
@@ -142,11 +152,12 @@ COPY xwiki/hibernate.cfg.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cf
 # version-specific logger levels it defines: the appender definition is inserted right after the opening
 # <configuration> tag and its reference right after the existing "stdout" one.
 COPY xwiki/logback-filelog-appender.xml xwiki/logback-filelog-ref.xml /tmp/
-RUN LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml && \
+RUN set -eux; \
+  LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml; \
   sed -e '/<configuration/r /tmp/logback-filelog-appender.xml' \
       -e '/ref="stdout"/r /tmp/logback-filelog-ref.xml' \
-      "$LOGBACK" > "$LOGBACK.new" && \
-  mv "$LOGBACK.new" "$LOGBACK" && \
+      "$LOGBACK" > "$LOGBACK.new"; \
+  mv "$LOGBACK.new" "$LOGBACK"; \
   rm -f /tmp/logback-filelog-appender.xml /tmp/logback-filelog-ref.xml
 
 # Set a specific distribution id in XWiki for this docker packaging.

--- a/17/mariadb-tomcat/Dockerfile
+++ b/17/mariadb-tomcat/Dockerfile
@@ -50,7 +50,8 @@ LABEL org.opencontainers.image.licenses='LGPL-2.1'
 # true (no DISPLAY is set), so by default the JVM uses the headless backend (libawt_headless.so, no X11 deps) and the
 # problem does not appear; installing these libraries keeps image parsing working when a user forces non-headless mode
 # via -Djava.awt.headless=false or by setting a DISPLAY variable.
-RUN apt-get update && \
+RUN set -eux; \
+  apt-get update; \
   apt-get --no-install-recommends -y install \
     curl \
     unzip \
@@ -65,7 +66,7 @@ RUN apt-get update && \
     libx11-xcb1 \
     libnss3 \
     libxml2 \
-    libxslt1.1 && \
+    libxslt1.1; \
   rm -rf /var/lib/apt/lists/*
 
 # Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
@@ -85,24 +86,31 @@ ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-ti
 # automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
 # would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
 # (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
-# needed.
+# needed. The deb packages install into /opt/libreoffice<major>.<minor>, so the symlink target is derived from
+# LIBREOFFICE_VERSION by stripping its patch component rather than by globbing /opt. The -n flag of ln is what makes it
+# replace /opt/libreoffice itself: without it, ln dereferences an already-existing symlink to a directory and creates
+# the new link inside that directory instead. We then check that the symlink resolves to an actual soffice binary:
+# since it is the only thing making JODConverter find LibreOffice, an installation landing elsewhere must fail the
+# build rather than produce an image where office import/export silently doesn't work.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN LO_ARCH="$(dpkg --print-architecture)" && \
+RUN set -eux; \
+  LO_ARCH="$(dpkg --print-architecture)"; \
   case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
-  esac && \
-  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
-  echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
-  mkdir -p /tmp/libreoffice && \
-  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
-  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb && \
-  ln -fs $(ls -d /opt/libreoffice*) /opt/libreoffice && \
+  esac; \
+  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz"; \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz; \
+  echo "$LO_SHA256 */tmp/libreoffice.tar.gz" | sha256sum --strict -c -; \
+  mkdir -p /tmp/libreoffice; \
+  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz; \
+  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb; \
+  ln -fns "/opt/libreoffice${LIBREOFFICE_VERSION%.*}" /opt/libreoffice; \
+  test -x /opt/libreoffice/program/soffice; \
   rm -rf /tmp/libreoffice /tmp/libreoffice.tar.gz
 
 # Install XWiki as the ROOT webapp context in Tomcat
@@ -111,12 +119,13 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
 ENV XWIKI_VERSION="17.10.11"
 ENV XWIKI_URL_PREFIX "https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-distribution-war/${XWIKI_VERSION}"
 ENV XWIKI_DOWNLOAD_SHA256 c52f9330775dd822eb7af3d9abc84a8c2fd82a295e0233379a0d27ee48722f5a
-RUN rm -rf /usr/local/tomcat/webapps/* && \
-  mkdir -p /usr/local/tomcat/temp && \
-  mkdir -p /usr/local/xwiki/data && \
-  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
-  echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
-  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
+RUN set -eux; \
+  rm -rf /usr/local/tomcat/webapps/*; \
+  mkdir -p /usr/local/tomcat/temp; \
+  mkdir -p /usr/local/xwiki/data; \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war; \
+  echo "$XWIKI_DOWNLOAD_SHA256 *xwiki.war" | sha256sum --strict -c -; \
+  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war; \
   rm -f xwiki.war
 
 # Copy the JDBC driver in the XWiki webapp
@@ -127,8 +136,9 @@ ENV MARIADB_JDBC_SHA256="11e3bb5bbf8ef0e806ae4d6c5d5033fedf7262cc777f0190bde8a2f
 ENV MARIADB_JDBC_PREFIX="https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/${MARIADB_JDBC_VERSION}"
 ENV MARIADB_JDBC_ARTIFACT="mariadb-java-client-${MARIADB_JDBC_VERSION}.jar"
 ENV MARIADB_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${MARIADB_JDBC_ARTIFACT}"
-RUN curl $CURL_OPTIONS "${MARIADB_JDBC_PREFIX}/${MARIADB_JDBC_ARTIFACT}" -o $MARIADB_JDBC_TARGET && \
-  echo "$MARIADB_JDBC_SHA256 $MARIADB_JDBC_TARGET" | sha256sum -c -
+RUN set -eux; \
+  curl $CURL_OPTIONS "${MARIADB_JDBC_PREFIX}/${MARIADB_JDBC_ARTIFACT}" -o $MARIADB_JDBC_TARGET; \
+  echo "$MARIADB_JDBC_SHA256 *$MARIADB_JDBC_TARGET" | sha256sum --strict -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki
 COPY tomcat/setenv.sh /usr/local/tomcat/bin/
@@ -142,11 +152,12 @@ COPY xwiki/hibernate.cfg.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cf
 # version-specific logger levels it defines: the appender definition is inserted right after the opening
 # <configuration> tag and its reference right after the existing "stdout" one.
 COPY xwiki/logback-filelog-appender.xml xwiki/logback-filelog-ref.xml /tmp/
-RUN LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml && \
+RUN set -eux; \
+  LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml; \
   sed -e '/<configuration/r /tmp/logback-filelog-appender.xml' \
       -e '/ref="stdout"/r /tmp/logback-filelog-ref.xml' \
-      "$LOGBACK" > "$LOGBACK.new" && \
-  mv "$LOGBACK.new" "$LOGBACK" && \
+      "$LOGBACK" > "$LOGBACK.new"; \
+  mv "$LOGBACK.new" "$LOGBACK"; \
   rm -f /tmp/logback-filelog-appender.xml /tmp/logback-filelog-ref.xml
 
 # Set a specific distribution id in XWiki for this docker packaging.

--- a/17/mysql-tomcat/Dockerfile
+++ b/17/mysql-tomcat/Dockerfile
@@ -50,7 +50,8 @@ LABEL org.opencontainers.image.licenses='LGPL-2.1'
 # true (no DISPLAY is set), so by default the JVM uses the headless backend (libawt_headless.so, no X11 deps) and the
 # problem does not appear; installing these libraries keeps image parsing working when a user forces non-headless mode
 # via -Djava.awt.headless=false or by setting a DISPLAY variable.
-RUN apt-get update && \
+RUN set -eux; \
+  apt-get update; \
   apt-get --no-install-recommends -y install \
     curl \
     unzip \
@@ -65,7 +66,7 @@ RUN apt-get update && \
     libx11-xcb1 \
     libnss3 \
     libxml2 \
-    libxslt1.1 && \
+    libxslt1.1; \
   rm -rf /var/lib/apt/lists/*
 
 # Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
@@ -85,24 +86,31 @@ ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-ti
 # automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
 # would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
 # (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
-# needed.
+# needed. The deb packages install into /opt/libreoffice<major>.<minor>, so the symlink target is derived from
+# LIBREOFFICE_VERSION by stripping its patch component rather than by globbing /opt. The -n flag of ln is what makes it
+# replace /opt/libreoffice itself: without it, ln dereferences an already-existing symlink to a directory and creates
+# the new link inside that directory instead. We then check that the symlink resolves to an actual soffice binary:
+# since it is the only thing making JODConverter find LibreOffice, an installation landing elsewhere must fail the
+# build rather than produce an image where office import/export silently doesn't work.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN LO_ARCH="$(dpkg --print-architecture)" && \
+RUN set -eux; \
+  LO_ARCH="$(dpkg --print-architecture)"; \
   case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
-  esac && \
-  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
-  echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
-  mkdir -p /tmp/libreoffice && \
-  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
-  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb && \
-  ln -fs $(ls -d /opt/libreoffice*) /opt/libreoffice && \
+  esac; \
+  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz"; \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz; \
+  echo "$LO_SHA256 */tmp/libreoffice.tar.gz" | sha256sum --strict -c -; \
+  mkdir -p /tmp/libreoffice; \
+  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz; \
+  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb; \
+  ln -fns "/opt/libreoffice${LIBREOFFICE_VERSION%.*}" /opt/libreoffice; \
+  test -x /opt/libreoffice/program/soffice; \
   rm -rf /tmp/libreoffice /tmp/libreoffice.tar.gz
 
 # Install XWiki as the ROOT webapp context in Tomcat
@@ -111,12 +119,13 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
 ENV XWIKI_VERSION="17.10.11"
 ENV XWIKI_URL_PREFIX "https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-distribution-war/${XWIKI_VERSION}"
 ENV XWIKI_DOWNLOAD_SHA256 c52f9330775dd822eb7af3d9abc84a8c2fd82a295e0233379a0d27ee48722f5a
-RUN rm -rf /usr/local/tomcat/webapps/* && \
-  mkdir -p /usr/local/tomcat/temp && \
-  mkdir -p /usr/local/xwiki/data && \
-  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
-  echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
-  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
+RUN set -eux; \
+  rm -rf /usr/local/tomcat/webapps/*; \
+  mkdir -p /usr/local/tomcat/temp; \
+  mkdir -p /usr/local/xwiki/data; \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war; \
+  echo "$XWIKI_DOWNLOAD_SHA256 *xwiki.war" | sha256sum --strict -c -; \
+  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war; \
   rm -f xwiki.war
 
 # Copy the JDBC driver in the XWiki webapp
@@ -127,8 +136,9 @@ ENV MYSQL_JDBC_SHA256="0353648eaa1c91e0f4020c959abf756bc866ffd583df22ae6b6f6e0cb
 ENV MYSQL_JDBC_PREFIX="https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/${MYSQL_JDBC_VERSION}"
 ENV MYSQL_JDBC_ARTIFACT="mysql-connector-j-${MYSQL_JDBC_VERSION}.jar"
 ENV MYSQL_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${MYSQL_JDBC_ARTIFACT}"
-RUN curl $CURL_OPTIONS "${MYSQL_JDBC_PREFIX}/${MYSQL_JDBC_ARTIFACT}" -o $MYSQL_JDBC_TARGET && \
-  echo "$MYSQL_JDBC_SHA256 $MYSQL_JDBC_TARGET" | sha256sum -c -
+RUN set -eux; \
+  curl $CURL_OPTIONS "${MYSQL_JDBC_PREFIX}/${MYSQL_JDBC_ARTIFACT}" -o $MYSQL_JDBC_TARGET; \
+  echo "$MYSQL_JDBC_SHA256 *$MYSQL_JDBC_TARGET" | sha256sum --strict -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki
 COPY tomcat/setenv.sh /usr/local/tomcat/bin/
@@ -142,11 +152,12 @@ COPY xwiki/hibernate.cfg.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cf
 # version-specific logger levels it defines: the appender definition is inserted right after the opening
 # <configuration> tag and its reference right after the existing "stdout" one.
 COPY xwiki/logback-filelog-appender.xml xwiki/logback-filelog-ref.xml /tmp/
-RUN LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml && \
+RUN set -eux; \
+  LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml; \
   sed -e '/<configuration/r /tmp/logback-filelog-appender.xml' \
       -e '/ref="stdout"/r /tmp/logback-filelog-ref.xml' \
-      "$LOGBACK" > "$LOGBACK.new" && \
-  mv "$LOGBACK.new" "$LOGBACK" && \
+      "$LOGBACK" > "$LOGBACK.new"; \
+  mv "$LOGBACK.new" "$LOGBACK"; \
   rm -f /tmp/logback-filelog-appender.xml /tmp/logback-filelog-ref.xml
 
 # Set a specific distribution id in XWiki for this docker packaging.

--- a/17/postgres-tomcat/Dockerfile
+++ b/17/postgres-tomcat/Dockerfile
@@ -50,7 +50,8 @@ LABEL org.opencontainers.image.licenses='LGPL-2.1'
 # true (no DISPLAY is set), so by default the JVM uses the headless backend (libawt_headless.so, no X11 deps) and the
 # problem does not appear; installing these libraries keeps image parsing working when a user forces non-headless mode
 # via -Djava.awt.headless=false or by setting a DISPLAY variable.
-RUN apt-get update && \
+RUN set -eux; \
+  apt-get update; \
   apt-get --no-install-recommends -y install \
     curl \
     unzip \
@@ -65,7 +66,7 @@ RUN apt-get update && \
     libx11-xcb1 \
     libnss3 \
     libxml2 \
-    libxslt1.1 && \
+    libxslt1.1; \
   rm -rf /var/lib/apt/lists/*
 
 # Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
@@ -85,24 +86,31 @@ ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-ti
 # automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
 # would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
 # (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
-# needed.
+# needed. The deb packages install into /opt/libreoffice<major>.<minor>, so the symlink target is derived from
+# LIBREOFFICE_VERSION by stripping its patch component rather than by globbing /opt. The -n flag of ln is what makes it
+# replace /opt/libreoffice itself: without it, ln dereferences an already-existing symlink to a directory and creates
+# the new link inside that directory instead. We then check that the symlink resolves to an actual soffice binary:
+# since it is the only thing making JODConverter find LibreOffice, an installation landing elsewhere must fail the
+# build rather than produce an image where office import/export silently doesn't work.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN LO_ARCH="$(dpkg --print-architecture)" && \
+RUN set -eux; \
+  LO_ARCH="$(dpkg --print-architecture)"; \
   case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
-  esac && \
-  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
-  echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
-  mkdir -p /tmp/libreoffice && \
-  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
-  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb && \
-  ln -fs $(ls -d /opt/libreoffice*) /opt/libreoffice && \
+  esac; \
+  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz"; \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz; \
+  echo "$LO_SHA256 */tmp/libreoffice.tar.gz" | sha256sum --strict -c -; \
+  mkdir -p /tmp/libreoffice; \
+  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz; \
+  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb; \
+  ln -fns "/opt/libreoffice${LIBREOFFICE_VERSION%.*}" /opt/libreoffice; \
+  test -x /opt/libreoffice/program/soffice; \
   rm -rf /tmp/libreoffice /tmp/libreoffice.tar.gz
 
 # Install XWiki as the ROOT webapp context in Tomcat
@@ -111,12 +119,13 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
 ENV XWIKI_VERSION="17.10.11"
 ENV XWIKI_URL_PREFIX "https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-distribution-war/${XWIKI_VERSION}"
 ENV XWIKI_DOWNLOAD_SHA256 c52f9330775dd822eb7af3d9abc84a8c2fd82a295e0233379a0d27ee48722f5a
-RUN rm -rf /usr/local/tomcat/webapps/* && \
-  mkdir -p /usr/local/tomcat/temp && \
-  mkdir -p /usr/local/xwiki/data && \
-  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
-  echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
-  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
+RUN set -eux; \
+  rm -rf /usr/local/tomcat/webapps/*; \
+  mkdir -p /usr/local/tomcat/temp; \
+  mkdir -p /usr/local/xwiki/data; \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war; \
+  echo "$XWIKI_DOWNLOAD_SHA256 *xwiki.war" | sha256sum --strict -c -; \
+  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war; \
   rm -f xwiki.war
 
 # Copy the JDBC driver in the XWiki webapp
@@ -127,8 +136,9 @@ ENV POSTGRES_JDBC_SHA256="6e0e4cc2d8cae902084f8a2b18728b073a6fd9d1f87c9d8bff8f29
 ENV POSTGRES_JDBC_PREFIX="https://repo1.maven.org/maven2/org/postgresql/postgresql/${POSTGRES_JDBC_VERSION}"
 ENV POSTGRES_JDBC_ARTIFACT="postgresql-${POSTGRES_JDBC_VERSION}.jar"
 ENV POSTGRES_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${POSTGRES_JDBC_ARTIFACT}"
-RUN curl $CURL_OPTIONS "${POSTGRES_JDBC_PREFIX}/${POSTGRES_JDBC_ARTIFACT}" -o $POSTGRES_JDBC_TARGET && \
-  echo "$POSTGRES_JDBC_SHA256 $POSTGRES_JDBC_TARGET" | sha256sum -c -
+RUN set -eux; \
+  curl $CURL_OPTIONS "${POSTGRES_JDBC_PREFIX}/${POSTGRES_JDBC_ARTIFACT}" -o $POSTGRES_JDBC_TARGET; \
+  echo "$POSTGRES_JDBC_SHA256 *$POSTGRES_JDBC_TARGET" | sha256sum --strict -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki
 COPY tomcat/setenv.sh /usr/local/tomcat/bin/
@@ -142,11 +152,12 @@ COPY xwiki/hibernate.cfg.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cf
 # version-specific logger levels it defines: the appender definition is inserted right after the opening
 # <configuration> tag and its reference right after the existing "stdout" one.
 COPY xwiki/logback-filelog-appender.xml xwiki/logback-filelog-ref.xml /tmp/
-RUN LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml && \
+RUN set -eux; \
+  LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml; \
   sed -e '/<configuration/r /tmp/logback-filelog-appender.xml' \
       -e '/ref="stdout"/r /tmp/logback-filelog-ref.xml' \
-      "$LOGBACK" > "$LOGBACK.new" && \
-  mv "$LOGBACK.new" "$LOGBACK" && \
+      "$LOGBACK" > "$LOGBACK.new"; \
+  mv "$LOGBACK.new" "$LOGBACK"; \
   rm -f /tmp/logback-filelog-appender.xml /tmp/logback-filelog-ref.xml
 
 # Set a specific distribution id in XWiki for this docker packaging.

--- a/18.4/mariadb-tomcat/Dockerfile
+++ b/18.4/mariadb-tomcat/Dockerfile
@@ -50,7 +50,8 @@ LABEL org.opencontainers.image.licenses='LGPL-2.1'
 # true (no DISPLAY is set), so by default the JVM uses the headless backend (libawt_headless.so, no X11 deps) and the
 # problem does not appear; installing these libraries keeps image parsing working when a user forces non-headless mode
 # via -Djava.awt.headless=false or by setting a DISPLAY variable.
-RUN apt-get update && \
+RUN set -eux; \
+  apt-get update; \
   apt-get --no-install-recommends -y install \
     curl \
     unzip \
@@ -65,7 +66,7 @@ RUN apt-get update && \
     libx11-xcb1 \
     libnss3 \
     libxml2 \
-    libxslt1.1 && \
+    libxslt1.1; \
   rm -rf /var/lib/apt/lists/*
 
 # Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
@@ -85,24 +86,31 @@ ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-ti
 # automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
 # would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
 # (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
-# needed.
+# needed. The deb packages install into /opt/libreoffice<major>.<minor>, so the symlink target is derived from
+# LIBREOFFICE_VERSION by stripping its patch component rather than by globbing /opt. The -n flag of ln is what makes it
+# replace /opt/libreoffice itself: without it, ln dereferences an already-existing symlink to a directory and creates
+# the new link inside that directory instead. We then check that the symlink resolves to an actual soffice binary:
+# since it is the only thing making JODConverter find LibreOffice, an installation landing elsewhere must fail the
+# build rather than produce an image where office import/export silently doesn't work.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN LO_ARCH="$(dpkg --print-architecture)" && \
+RUN set -eux; \
+  LO_ARCH="$(dpkg --print-architecture)"; \
   case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
-  esac && \
-  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
-  echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
-  mkdir -p /tmp/libreoffice && \
-  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
-  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb && \
-  ln -fs $(ls -d /opt/libreoffice*) /opt/libreoffice && \
+  esac; \
+  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz"; \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz; \
+  echo "$LO_SHA256 */tmp/libreoffice.tar.gz" | sha256sum --strict -c -; \
+  mkdir -p /tmp/libreoffice; \
+  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz; \
+  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb; \
+  ln -fns "/opt/libreoffice${LIBREOFFICE_VERSION%.*}" /opt/libreoffice; \
+  test -x /opt/libreoffice/program/soffice; \
   rm -rf /tmp/libreoffice /tmp/libreoffice.tar.gz
 
 # Install XWiki as the ROOT webapp context in Tomcat
@@ -111,12 +119,13 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
 ENV XWIKI_VERSION="18.4.3"
 ENV XWIKI_URL_PREFIX "https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-distribution-war/${XWIKI_VERSION}"
 ENV XWIKI_DOWNLOAD_SHA256 d9dfdb0996e813a9e8f73298f06afdbc52431ddfff4dbdf03d0c4fa359d0b55b
-RUN rm -rf /usr/local/tomcat/webapps/* && \
-  mkdir -p /usr/local/tomcat/temp && \
-  mkdir -p /usr/local/xwiki/data && \
-  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
-  echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
-  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
+RUN set -eux; \
+  rm -rf /usr/local/tomcat/webapps/*; \
+  mkdir -p /usr/local/tomcat/temp; \
+  mkdir -p /usr/local/xwiki/data; \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war; \
+  echo "$XWIKI_DOWNLOAD_SHA256 *xwiki.war" | sha256sum --strict -c -; \
+  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war; \
   rm -f xwiki.war
 
 # Copy the JDBC driver in the XWiki webapp
@@ -127,8 +136,9 @@ ENV MARIADB_JDBC_SHA256="11e3bb5bbf8ef0e806ae4d6c5d5033fedf7262cc777f0190bde8a2f
 ENV MARIADB_JDBC_PREFIX="https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/${MARIADB_JDBC_VERSION}"
 ENV MARIADB_JDBC_ARTIFACT="mariadb-java-client-${MARIADB_JDBC_VERSION}.jar"
 ENV MARIADB_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${MARIADB_JDBC_ARTIFACT}"
-RUN curl $CURL_OPTIONS "${MARIADB_JDBC_PREFIX}/${MARIADB_JDBC_ARTIFACT}" -o $MARIADB_JDBC_TARGET && \
-  echo "$MARIADB_JDBC_SHA256 $MARIADB_JDBC_TARGET" | sha256sum -c -
+RUN set -eux; \
+  curl $CURL_OPTIONS "${MARIADB_JDBC_PREFIX}/${MARIADB_JDBC_ARTIFACT}" -o $MARIADB_JDBC_TARGET; \
+  echo "$MARIADB_JDBC_SHA256 *$MARIADB_JDBC_TARGET" | sha256sum --strict -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki
 COPY tomcat/setenv.sh /usr/local/tomcat/bin/
@@ -142,11 +152,12 @@ COPY xwiki/hibernate.cfg.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cf
 # version-specific logger levels it defines: the appender definition is inserted right after the opening
 # <configuration> tag and its reference right after the existing "stdout" one.
 COPY xwiki/logback-filelog-appender.xml xwiki/logback-filelog-ref.xml /tmp/
-RUN LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml && \
+RUN set -eux; \
+  LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml; \
   sed -e '/<configuration/r /tmp/logback-filelog-appender.xml' \
       -e '/ref="stdout"/r /tmp/logback-filelog-ref.xml' \
-      "$LOGBACK" > "$LOGBACK.new" && \
-  mv "$LOGBACK.new" "$LOGBACK" && \
+      "$LOGBACK" > "$LOGBACK.new"; \
+  mv "$LOGBACK.new" "$LOGBACK"; \
   rm -f /tmp/logback-filelog-appender.xml /tmp/logback-filelog-ref.xml
 
 # Set a specific distribution id in XWiki for this docker packaging.

--- a/18.4/mysql-tomcat/Dockerfile
+++ b/18.4/mysql-tomcat/Dockerfile
@@ -50,7 +50,8 @@ LABEL org.opencontainers.image.licenses='LGPL-2.1'
 # true (no DISPLAY is set), so by default the JVM uses the headless backend (libawt_headless.so, no X11 deps) and the
 # problem does not appear; installing these libraries keeps image parsing working when a user forces non-headless mode
 # via -Djava.awt.headless=false or by setting a DISPLAY variable.
-RUN apt-get update && \
+RUN set -eux; \
+  apt-get update; \
   apt-get --no-install-recommends -y install \
     curl \
     unzip \
@@ -65,7 +66,7 @@ RUN apt-get update && \
     libx11-xcb1 \
     libnss3 \
     libxml2 \
-    libxslt1.1 && \
+    libxslt1.1; \
   rm -rf /var/lib/apt/lists/*
 
 # Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
@@ -85,24 +86,31 @@ ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-ti
 # automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
 # would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
 # (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
-# needed.
+# needed. The deb packages install into /opt/libreoffice<major>.<minor>, so the symlink target is derived from
+# LIBREOFFICE_VERSION by stripping its patch component rather than by globbing /opt. The -n flag of ln is what makes it
+# replace /opt/libreoffice itself: without it, ln dereferences an already-existing symlink to a directory and creates
+# the new link inside that directory instead. We then check that the symlink resolves to an actual soffice binary:
+# since it is the only thing making JODConverter find LibreOffice, an installation landing elsewhere must fail the
+# build rather than produce an image where office import/export silently doesn't work.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN LO_ARCH="$(dpkg --print-architecture)" && \
+RUN set -eux; \
+  LO_ARCH="$(dpkg --print-architecture)"; \
   case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
-  esac && \
-  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
-  echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
-  mkdir -p /tmp/libreoffice && \
-  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
-  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb && \
-  ln -fs $(ls -d /opt/libreoffice*) /opt/libreoffice && \
+  esac; \
+  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz"; \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz; \
+  echo "$LO_SHA256 */tmp/libreoffice.tar.gz" | sha256sum --strict -c -; \
+  mkdir -p /tmp/libreoffice; \
+  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz; \
+  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb; \
+  ln -fns "/opt/libreoffice${LIBREOFFICE_VERSION%.*}" /opt/libreoffice; \
+  test -x /opt/libreoffice/program/soffice; \
   rm -rf /tmp/libreoffice /tmp/libreoffice.tar.gz
 
 # Install XWiki as the ROOT webapp context in Tomcat
@@ -111,12 +119,13 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
 ENV XWIKI_VERSION="18.4.3"
 ENV XWIKI_URL_PREFIX "https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-distribution-war/${XWIKI_VERSION}"
 ENV XWIKI_DOWNLOAD_SHA256 d9dfdb0996e813a9e8f73298f06afdbc52431ddfff4dbdf03d0c4fa359d0b55b
-RUN rm -rf /usr/local/tomcat/webapps/* && \
-  mkdir -p /usr/local/tomcat/temp && \
-  mkdir -p /usr/local/xwiki/data && \
-  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
-  echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
-  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
+RUN set -eux; \
+  rm -rf /usr/local/tomcat/webapps/*; \
+  mkdir -p /usr/local/tomcat/temp; \
+  mkdir -p /usr/local/xwiki/data; \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war; \
+  echo "$XWIKI_DOWNLOAD_SHA256 *xwiki.war" | sha256sum --strict -c -; \
+  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war; \
   rm -f xwiki.war
 
 # Copy the JDBC driver in the XWiki webapp
@@ -127,8 +136,9 @@ ENV MYSQL_JDBC_SHA256="0353648eaa1c91e0f4020c959abf756bc866ffd583df22ae6b6f6e0cb
 ENV MYSQL_JDBC_PREFIX="https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/${MYSQL_JDBC_VERSION}"
 ENV MYSQL_JDBC_ARTIFACT="mysql-connector-j-${MYSQL_JDBC_VERSION}.jar"
 ENV MYSQL_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${MYSQL_JDBC_ARTIFACT}"
-RUN curl $CURL_OPTIONS "${MYSQL_JDBC_PREFIX}/${MYSQL_JDBC_ARTIFACT}" -o $MYSQL_JDBC_TARGET && \
-  echo "$MYSQL_JDBC_SHA256 $MYSQL_JDBC_TARGET" | sha256sum -c -
+RUN set -eux; \
+  curl $CURL_OPTIONS "${MYSQL_JDBC_PREFIX}/${MYSQL_JDBC_ARTIFACT}" -o $MYSQL_JDBC_TARGET; \
+  echo "$MYSQL_JDBC_SHA256 *$MYSQL_JDBC_TARGET" | sha256sum --strict -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki
 COPY tomcat/setenv.sh /usr/local/tomcat/bin/
@@ -142,11 +152,12 @@ COPY xwiki/hibernate.cfg.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cf
 # version-specific logger levels it defines: the appender definition is inserted right after the opening
 # <configuration> tag and its reference right after the existing "stdout" one.
 COPY xwiki/logback-filelog-appender.xml xwiki/logback-filelog-ref.xml /tmp/
-RUN LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml && \
+RUN set -eux; \
+  LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml; \
   sed -e '/<configuration/r /tmp/logback-filelog-appender.xml' \
       -e '/ref="stdout"/r /tmp/logback-filelog-ref.xml' \
-      "$LOGBACK" > "$LOGBACK.new" && \
-  mv "$LOGBACK.new" "$LOGBACK" && \
+      "$LOGBACK" > "$LOGBACK.new"; \
+  mv "$LOGBACK.new" "$LOGBACK"; \
   rm -f /tmp/logback-filelog-appender.xml /tmp/logback-filelog-ref.xml
 
 # Set a specific distribution id in XWiki for this docker packaging.

--- a/18.4/postgres-tomcat/Dockerfile
+++ b/18.4/postgres-tomcat/Dockerfile
@@ -50,7 +50,8 @@ LABEL org.opencontainers.image.licenses='LGPL-2.1'
 # true (no DISPLAY is set), so by default the JVM uses the headless backend (libawt_headless.so, no X11 deps) and the
 # problem does not appear; installing these libraries keeps image parsing working when a user forces non-headless mode
 # via -Djava.awt.headless=false or by setting a DISPLAY variable.
-RUN apt-get update && \
+RUN set -eux; \
+  apt-get update; \
   apt-get --no-install-recommends -y install \
     curl \
     unzip \
@@ -65,7 +66,7 @@ RUN apt-get update && \
     libx11-xcb1 \
     libnss3 \
     libxml2 \
-    libxslt1.1 && \
+    libxslt1.1; \
   rm -rf /var/lib/apt/lists/*
 
 # Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
@@ -85,24 +86,31 @@ ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-ti
 # automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
 # would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
 # (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
-# needed.
+# needed. The deb packages install into /opt/libreoffice<major>.<minor>, so the symlink target is derived from
+# LIBREOFFICE_VERSION by stripping its patch component rather than by globbing /opt. The -n flag of ln is what makes it
+# replace /opt/libreoffice itself: without it, ln dereferences an already-existing symlink to a directory and creates
+# the new link inside that directory instead. We then check that the symlink resolves to an actual soffice binary:
+# since it is the only thing making JODConverter find LibreOffice, an installation landing elsewhere must fail the
+# build rather than produce an image where office import/export silently doesn't work.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN LO_ARCH="$(dpkg --print-architecture)" && \
+RUN set -eux; \
+  LO_ARCH="$(dpkg --print-architecture)"; \
   case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
-  esac && \
-  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
-  echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
-  mkdir -p /tmp/libreoffice && \
-  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
-  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb && \
-  ln -fs $(ls -d /opt/libreoffice*) /opt/libreoffice && \
+  esac; \
+  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz"; \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz; \
+  echo "$LO_SHA256 */tmp/libreoffice.tar.gz" | sha256sum --strict -c -; \
+  mkdir -p /tmp/libreoffice; \
+  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz; \
+  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb; \
+  ln -fns "/opt/libreoffice${LIBREOFFICE_VERSION%.*}" /opt/libreoffice; \
+  test -x /opt/libreoffice/program/soffice; \
   rm -rf /tmp/libreoffice /tmp/libreoffice.tar.gz
 
 # Install XWiki as the ROOT webapp context in Tomcat
@@ -111,12 +119,13 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
 ENV XWIKI_VERSION="18.4.3"
 ENV XWIKI_URL_PREFIX "https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-distribution-war/${XWIKI_VERSION}"
 ENV XWIKI_DOWNLOAD_SHA256 d9dfdb0996e813a9e8f73298f06afdbc52431ddfff4dbdf03d0c4fa359d0b55b
-RUN rm -rf /usr/local/tomcat/webapps/* && \
-  mkdir -p /usr/local/tomcat/temp && \
-  mkdir -p /usr/local/xwiki/data && \
-  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
-  echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
-  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
+RUN set -eux; \
+  rm -rf /usr/local/tomcat/webapps/*; \
+  mkdir -p /usr/local/tomcat/temp; \
+  mkdir -p /usr/local/xwiki/data; \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war; \
+  echo "$XWIKI_DOWNLOAD_SHA256 *xwiki.war" | sha256sum --strict -c -; \
+  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war; \
   rm -f xwiki.war
 
 # Copy the JDBC driver in the XWiki webapp
@@ -127,8 +136,9 @@ ENV POSTGRES_JDBC_SHA256="6e0e4cc2d8cae902084f8a2b18728b073a6fd9d1f87c9d8bff8f29
 ENV POSTGRES_JDBC_PREFIX="https://repo1.maven.org/maven2/org/postgresql/postgresql/${POSTGRES_JDBC_VERSION}"
 ENV POSTGRES_JDBC_ARTIFACT="postgresql-${POSTGRES_JDBC_VERSION}.jar"
 ENV POSTGRES_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${POSTGRES_JDBC_ARTIFACT}"
-RUN curl $CURL_OPTIONS "${POSTGRES_JDBC_PREFIX}/${POSTGRES_JDBC_ARTIFACT}" -o $POSTGRES_JDBC_TARGET && \
-  echo "$POSTGRES_JDBC_SHA256 $POSTGRES_JDBC_TARGET" | sha256sum -c -
+RUN set -eux; \
+  curl $CURL_OPTIONS "${POSTGRES_JDBC_PREFIX}/${POSTGRES_JDBC_ARTIFACT}" -o $POSTGRES_JDBC_TARGET; \
+  echo "$POSTGRES_JDBC_SHA256 *$POSTGRES_JDBC_TARGET" | sha256sum --strict -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki
 COPY tomcat/setenv.sh /usr/local/tomcat/bin/
@@ -142,11 +152,12 @@ COPY xwiki/hibernate.cfg.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cf
 # version-specific logger levels it defines: the appender definition is inserted right after the opening
 # <configuration> tag and its reference right after the existing "stdout" one.
 COPY xwiki/logback-filelog-appender.xml xwiki/logback-filelog-ref.xml /tmp/
-RUN LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml && \
+RUN set -eux; \
+  LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml; \
   sed -e '/<configuration/r /tmp/logback-filelog-appender.xml' \
       -e '/ref="stdout"/r /tmp/logback-filelog-ref.xml' \
-      "$LOGBACK" > "$LOGBACK.new" && \
-  mv "$LOGBACK.new" "$LOGBACK" && \
+      "$LOGBACK" > "$LOGBACK.new"; \
+  mv "$LOGBACK.new" "$LOGBACK"; \
   rm -f /tmp/logback-filelog-appender.xml /tmp/logback-filelog-ref.xml
 
 # Set a specific distribution id in XWiki for this docker packaging.

--- a/18/mariadb-tomcat/Dockerfile
+++ b/18/mariadb-tomcat/Dockerfile
@@ -50,7 +50,8 @@ LABEL org.opencontainers.image.licenses='LGPL-2.1'
 # true (no DISPLAY is set), so by default the JVM uses the headless backend (libawt_headless.so, no X11 deps) and the
 # problem does not appear; installing these libraries keeps image parsing working when a user forces non-headless mode
 # via -Djava.awt.headless=false or by setting a DISPLAY variable.
-RUN apt-get update && \
+RUN set -eux; \
+  apt-get update; \
   apt-get --no-install-recommends -y install \
     curl \
     unzip \
@@ -65,7 +66,7 @@ RUN apt-get update && \
     libx11-xcb1 \
     libnss3 \
     libxml2 \
-    libxslt1.1 && \
+    libxslt1.1; \
   rm -rf /var/lib/apt/lists/*
 
 # Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
@@ -85,24 +86,31 @@ ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-ti
 # automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
 # would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
 # (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
-# needed.
+# needed. The deb packages install into /opt/libreoffice<major>.<minor>, so the symlink target is derived from
+# LIBREOFFICE_VERSION by stripping its patch component rather than by globbing /opt. The -n flag of ln is what makes it
+# replace /opt/libreoffice itself: without it, ln dereferences an already-existing symlink to a directory and creates
+# the new link inside that directory instead. We then check that the symlink resolves to an actual soffice binary:
+# since it is the only thing making JODConverter find LibreOffice, an installation landing elsewhere must fail the
+# build rather than produce an image where office import/export silently doesn't work.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN LO_ARCH="$(dpkg --print-architecture)" && \
+RUN set -eux; \
+  LO_ARCH="$(dpkg --print-architecture)"; \
   case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
-  esac && \
-  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
-  echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
-  mkdir -p /tmp/libreoffice && \
-  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
-  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb && \
-  ln -fs $(ls -d /opt/libreoffice*) /opt/libreoffice && \
+  esac; \
+  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz"; \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz; \
+  echo "$LO_SHA256 */tmp/libreoffice.tar.gz" | sha256sum --strict -c -; \
+  mkdir -p /tmp/libreoffice; \
+  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz; \
+  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb; \
+  ln -fns "/opt/libreoffice${LIBREOFFICE_VERSION%.*}" /opt/libreoffice; \
+  test -x /opt/libreoffice/program/soffice; \
   rm -rf /tmp/libreoffice /tmp/libreoffice.tar.gz
 
 # Install XWiki as the ROOT webapp context in Tomcat
@@ -111,12 +119,13 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
 ENV XWIKI_VERSION="18.6.0"
 ENV XWIKI_URL_PREFIX "https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-distribution-war/${XWIKI_VERSION}"
 ENV XWIKI_DOWNLOAD_SHA256 3f4d0210f57efd98be916379e18f4714c600312c22b288f20bbc0ff39a8a4fff
-RUN rm -rf /usr/local/tomcat/webapps/* && \
-  mkdir -p /usr/local/tomcat/temp && \
-  mkdir -p /usr/local/xwiki/data && \
-  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
-  echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
-  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
+RUN set -eux; \
+  rm -rf /usr/local/tomcat/webapps/*; \
+  mkdir -p /usr/local/tomcat/temp; \
+  mkdir -p /usr/local/xwiki/data; \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war; \
+  echo "$XWIKI_DOWNLOAD_SHA256 *xwiki.war" | sha256sum --strict -c -; \
+  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war; \
   rm -f xwiki.war
 
 # Copy the JDBC driver in the XWiki webapp
@@ -127,8 +136,9 @@ ENV MARIADB_JDBC_SHA256="11e3bb5bbf8ef0e806ae4d6c5d5033fedf7262cc777f0190bde8a2f
 ENV MARIADB_JDBC_PREFIX="https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/${MARIADB_JDBC_VERSION}"
 ENV MARIADB_JDBC_ARTIFACT="mariadb-java-client-${MARIADB_JDBC_VERSION}.jar"
 ENV MARIADB_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${MARIADB_JDBC_ARTIFACT}"
-RUN curl $CURL_OPTIONS "${MARIADB_JDBC_PREFIX}/${MARIADB_JDBC_ARTIFACT}" -o $MARIADB_JDBC_TARGET && \
-  echo "$MARIADB_JDBC_SHA256 $MARIADB_JDBC_TARGET" | sha256sum -c -
+RUN set -eux; \
+  curl $CURL_OPTIONS "${MARIADB_JDBC_PREFIX}/${MARIADB_JDBC_ARTIFACT}" -o $MARIADB_JDBC_TARGET; \
+  echo "$MARIADB_JDBC_SHA256 *$MARIADB_JDBC_TARGET" | sha256sum --strict -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki
 COPY tomcat/setenv.sh /usr/local/tomcat/bin/
@@ -142,11 +152,12 @@ COPY xwiki/hibernate.cfg.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cf
 # version-specific logger levels it defines: the appender definition is inserted right after the opening
 # <configuration> tag and its reference right after the existing "stdout" one.
 COPY xwiki/logback-filelog-appender.xml xwiki/logback-filelog-ref.xml /tmp/
-RUN LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml && \
+RUN set -eux; \
+  LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml; \
   sed -e '/<configuration/r /tmp/logback-filelog-appender.xml' \
       -e '/ref="stdout"/r /tmp/logback-filelog-ref.xml' \
-      "$LOGBACK" > "$LOGBACK.new" && \
-  mv "$LOGBACK.new" "$LOGBACK" && \
+      "$LOGBACK" > "$LOGBACK.new"; \
+  mv "$LOGBACK.new" "$LOGBACK"; \
   rm -f /tmp/logback-filelog-appender.xml /tmp/logback-filelog-ref.xml
 
 # Set a specific distribution id in XWiki for this docker packaging.

--- a/18/mysql-tomcat/Dockerfile
+++ b/18/mysql-tomcat/Dockerfile
@@ -50,7 +50,8 @@ LABEL org.opencontainers.image.licenses='LGPL-2.1'
 # true (no DISPLAY is set), so by default the JVM uses the headless backend (libawt_headless.so, no X11 deps) and the
 # problem does not appear; installing these libraries keeps image parsing working when a user forces non-headless mode
 # via -Djava.awt.headless=false or by setting a DISPLAY variable.
-RUN apt-get update && \
+RUN set -eux; \
+  apt-get update; \
   apt-get --no-install-recommends -y install \
     curl \
     unzip \
@@ -65,7 +66,7 @@ RUN apt-get update && \
     libx11-xcb1 \
     libnss3 \
     libxml2 \
-    libxslt1.1 && \
+    libxslt1.1; \
   rm -rf /var/lib/apt/lists/*
 
 # Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
@@ -85,24 +86,31 @@ ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-ti
 # automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
 # would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
 # (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
-# needed.
+# needed. The deb packages install into /opt/libreoffice<major>.<minor>, so the symlink target is derived from
+# LIBREOFFICE_VERSION by stripping its patch component rather than by globbing /opt. The -n flag of ln is what makes it
+# replace /opt/libreoffice itself: without it, ln dereferences an already-existing symlink to a directory and creates
+# the new link inside that directory instead. We then check that the symlink resolves to an actual soffice binary:
+# since it is the only thing making JODConverter find LibreOffice, an installation landing elsewhere must fail the
+# build rather than produce an image where office import/export silently doesn't work.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN LO_ARCH="$(dpkg --print-architecture)" && \
+RUN set -eux; \
+  LO_ARCH="$(dpkg --print-architecture)"; \
   case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
-  esac && \
-  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
-  echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
-  mkdir -p /tmp/libreoffice && \
-  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
-  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb && \
-  ln -fs $(ls -d /opt/libreoffice*) /opt/libreoffice && \
+  esac; \
+  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz"; \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz; \
+  echo "$LO_SHA256 */tmp/libreoffice.tar.gz" | sha256sum --strict -c -; \
+  mkdir -p /tmp/libreoffice; \
+  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz; \
+  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb; \
+  ln -fns "/opt/libreoffice${LIBREOFFICE_VERSION%.*}" /opt/libreoffice; \
+  test -x /opt/libreoffice/program/soffice; \
   rm -rf /tmp/libreoffice /tmp/libreoffice.tar.gz
 
 # Install XWiki as the ROOT webapp context in Tomcat
@@ -111,12 +119,13 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
 ENV XWIKI_VERSION="18.6.0"
 ENV XWIKI_URL_PREFIX "https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-distribution-war/${XWIKI_VERSION}"
 ENV XWIKI_DOWNLOAD_SHA256 3f4d0210f57efd98be916379e18f4714c600312c22b288f20bbc0ff39a8a4fff
-RUN rm -rf /usr/local/tomcat/webapps/* && \
-  mkdir -p /usr/local/tomcat/temp && \
-  mkdir -p /usr/local/xwiki/data && \
-  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
-  echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
-  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
+RUN set -eux; \
+  rm -rf /usr/local/tomcat/webapps/*; \
+  mkdir -p /usr/local/tomcat/temp; \
+  mkdir -p /usr/local/xwiki/data; \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war; \
+  echo "$XWIKI_DOWNLOAD_SHA256 *xwiki.war" | sha256sum --strict -c -; \
+  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war; \
   rm -f xwiki.war
 
 # Copy the JDBC driver in the XWiki webapp
@@ -127,8 +136,9 @@ ENV MYSQL_JDBC_SHA256="0353648eaa1c91e0f4020c959abf756bc866ffd583df22ae6b6f6e0cb
 ENV MYSQL_JDBC_PREFIX="https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/${MYSQL_JDBC_VERSION}"
 ENV MYSQL_JDBC_ARTIFACT="mysql-connector-j-${MYSQL_JDBC_VERSION}.jar"
 ENV MYSQL_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${MYSQL_JDBC_ARTIFACT}"
-RUN curl $CURL_OPTIONS "${MYSQL_JDBC_PREFIX}/${MYSQL_JDBC_ARTIFACT}" -o $MYSQL_JDBC_TARGET && \
-  echo "$MYSQL_JDBC_SHA256 $MYSQL_JDBC_TARGET" | sha256sum -c -
+RUN set -eux; \
+  curl $CURL_OPTIONS "${MYSQL_JDBC_PREFIX}/${MYSQL_JDBC_ARTIFACT}" -o $MYSQL_JDBC_TARGET; \
+  echo "$MYSQL_JDBC_SHA256 *$MYSQL_JDBC_TARGET" | sha256sum --strict -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki
 COPY tomcat/setenv.sh /usr/local/tomcat/bin/
@@ -142,11 +152,12 @@ COPY xwiki/hibernate.cfg.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cf
 # version-specific logger levels it defines: the appender definition is inserted right after the opening
 # <configuration> tag and its reference right after the existing "stdout" one.
 COPY xwiki/logback-filelog-appender.xml xwiki/logback-filelog-ref.xml /tmp/
-RUN LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml && \
+RUN set -eux; \
+  LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml; \
   sed -e '/<configuration/r /tmp/logback-filelog-appender.xml' \
       -e '/ref="stdout"/r /tmp/logback-filelog-ref.xml' \
-      "$LOGBACK" > "$LOGBACK.new" && \
-  mv "$LOGBACK.new" "$LOGBACK" && \
+      "$LOGBACK" > "$LOGBACK.new"; \
+  mv "$LOGBACK.new" "$LOGBACK"; \
   rm -f /tmp/logback-filelog-appender.xml /tmp/logback-filelog-ref.xml
 
 # Set a specific distribution id in XWiki for this docker packaging.

--- a/18/postgres-tomcat/Dockerfile
+++ b/18/postgres-tomcat/Dockerfile
@@ -50,7 +50,8 @@ LABEL org.opencontainers.image.licenses='LGPL-2.1'
 # true (no DISPLAY is set), so by default the JVM uses the headless backend (libawt_headless.so, no X11 deps) and the
 # problem does not appear; installing these libraries keeps image parsing working when a user forces non-headless mode
 # via -Djava.awt.headless=false or by setting a DISPLAY variable.
-RUN apt-get update && \
+RUN set -eux; \
+  apt-get update; \
   apt-get --no-install-recommends -y install \
     curl \
     unzip \
@@ -65,7 +66,7 @@ RUN apt-get update && \
     libx11-xcb1 \
     libnss3 \
     libxml2 \
-    libxslt1.1 && \
+    libxslt1.1; \
   rm -rf /var/lib/apt/lists/*
 
 # Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
@@ -85,24 +86,31 @@ ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-ti
 # automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
 # would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
 # (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
-# needed.
+# needed. The deb packages install into /opt/libreoffice<major>.<minor>, so the symlink target is derived from
+# LIBREOFFICE_VERSION by stripping its patch component rather than by globbing /opt. The -n flag of ln is what makes it
+# replace /opt/libreoffice itself: without it, ln dereferences an already-existing symlink to a directory and creates
+# the new link inside that directory instead. We then check that the symlink resolves to an actual soffice binary:
+# since it is the only thing making JODConverter find LibreOffice, an installation landing elsewhere must fail the
+# build rather than produce an image where office import/export silently doesn't work.
 ENV LIBREOFFICE_VERSION="25.8.7"
 ENV LIBREOFFICE_SHA256_AMD64="7f4d7b2e36921eec5122c655249a24cc88935ee357e8261fd3bccd15aa1f7b9f"
 ENV LIBREOFFICE_SHA256_ARM64="67e9b7dcdeae72c7aa1357345307e67376fc2b729a7f9ebfafb372b010e22ffa"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb"
-RUN LO_ARCH="$(dpkg --print-architecture)" && \
+RUN set -eux; \
+  LO_ARCH="$(dpkg --print-architecture)"; \
   case "$LO_ARCH" in \
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=$LIBREOFFICE_SHA256_AMD64 ;; \
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=$LIBREOFFICE_SHA256_ARM64 ;; \
     *) echo "Unsupported architecture [$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \
-  esac && \
-  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz" && \
-  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \
-  echo "$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \
-  mkdir -p /tmp/libreoffice && \
-  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \
-  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb && \
-  ln -fs $(ls -d /opt/libreoffice*) /opt/libreoffice && \
+  esac; \
+  LO_ARCHIVE="LibreOffice_${LIBREOFFICE_VERSION}_Linux_${LO_ARCH_FILE}_deb.tar.gz"; \
+  curl $CURL_OPTIONS "${LIBREOFFICE_URL_PREFIX}/${LO_ARCH_DIR}/${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz; \
+  echo "$LO_SHA256 */tmp/libreoffice.tar.gz" | sha256sum --strict -c -; \
+  mkdir -p /tmp/libreoffice; \
+  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz; \
+  dpkg -i /tmp/libreoffice/LibreOffice_${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb; \
+  ln -fns "/opt/libreoffice${LIBREOFFICE_VERSION%.*}" /opt/libreoffice; \
+  test -x /opt/libreoffice/program/soffice; \
   rm -rf /tmp/libreoffice /tmp/libreoffice.tar.gz
 
 # Install XWiki as the ROOT webapp context in Tomcat
@@ -111,12 +119,13 @@ RUN LO_ARCH="$(dpkg --print-architecture)" && \
 ENV XWIKI_VERSION="18.6.0"
 ENV XWIKI_URL_PREFIX "https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-distribution-war/${XWIKI_VERSION}"
 ENV XWIKI_DOWNLOAD_SHA256 3f4d0210f57efd98be916379e18f4714c600312c22b288f20bbc0ff39a8a4fff
-RUN rm -rf /usr/local/tomcat/webapps/* && \
-  mkdir -p /usr/local/tomcat/temp && \
-  mkdir -p /usr/local/xwiki/data && \
-  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war && \
-  echo "$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \
-  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \
+RUN set -eux; \
+  rm -rf /usr/local/tomcat/webapps/*; \
+  mkdir -p /usr/local/tomcat/temp; \
+  mkdir -p /usr/local/xwiki/data; \
+  curl $CURL_OPTIONS "${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-${XWIKI_VERSION}.war" -o xwiki.war; \
+  echo "$XWIKI_DOWNLOAD_SHA256 *xwiki.war" | sha256sum --strict -c -; \
+  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war; \
   rm -f xwiki.war
 
 # Copy the JDBC driver in the XWiki webapp
@@ -127,8 +136,9 @@ ENV POSTGRES_JDBC_SHA256="6e0e4cc2d8cae902084f8a2b18728b073a6fd9d1f87c9d8bff8f29
 ENV POSTGRES_JDBC_PREFIX="https://repo1.maven.org/maven2/org/postgresql/postgresql/${POSTGRES_JDBC_VERSION}"
 ENV POSTGRES_JDBC_ARTIFACT="postgresql-${POSTGRES_JDBC_VERSION}.jar"
 ENV POSTGRES_JDBC_TARGET="/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/${POSTGRES_JDBC_ARTIFACT}"
-RUN curl $CURL_OPTIONS "${POSTGRES_JDBC_PREFIX}/${POSTGRES_JDBC_ARTIFACT}" -o $POSTGRES_JDBC_TARGET && \
-  echo "$POSTGRES_JDBC_SHA256 $POSTGRES_JDBC_TARGET" | sha256sum -c -
+RUN set -eux; \
+  curl $CURL_OPTIONS "${POSTGRES_JDBC_PREFIX}/${POSTGRES_JDBC_ARTIFACT}" -o $POSTGRES_JDBC_TARGET; \
+  echo "$POSTGRES_JDBC_SHA256 *$POSTGRES_JDBC_TARGET" | sha256sum --strict -c -
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki
 COPY tomcat/setenv.sh /usr/local/tomcat/bin/
@@ -142,11 +152,12 @@ COPY xwiki/hibernate.cfg.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cf
 # version-specific logger levels it defines: the appender definition is inserted right after the opening
 # <configuration> tag and its reference right after the existing "stdout" one.
 COPY xwiki/logback-filelog-appender.xml xwiki/logback-filelog-ref.xml /tmp/
-RUN LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml && \
+RUN set -eux; \
+  LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml; \
   sed -e '/<configuration/r /tmp/logback-filelog-appender.xml' \
       -e '/ref="stdout"/r /tmp/logback-filelog-ref.xml' \
-      "$LOGBACK" > "$LOGBACK.new" && \
-  mv "$LOGBACK.new" "$LOGBACK" && \
+      "$LOGBACK" > "$LOGBACK.new"; \
+  mv "$LOGBACK.new" "$LOGBACK"; \
   rm -f /tmp/logback-filelog-appender.xml /tmp/logback-filelog-ref.xml
 
 # Set a specific distribution id in XWiki for this docker packaging.

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -50,7 +50,8 @@ LABEL org.opencontainers.image.licenses='LGPL-2.1'
 # true (no DISPLAY is set), so by default the JVM uses the headless backend (libawt_headless.so, no X11 deps) and the
 # problem does not appear; installing these libraries keeps image parsing working when a user forces non-headless mode
 # via -Djava.awt.headless=false or by setting a DISPLAY variable.
-RUN apt-get update && \\
+RUN set -eux; \\
+  apt-get update; \\
   apt-get --no-install-recommends -y install \\
     curl \\
     unzip \\
@@ -65,7 +66,7 @@ RUN apt-get update && \\
     libx11-xcb1 \\
     libnss3 \\
     libxml2 \\
-    libxslt1.1 && \\
+    libxslt1.1; \\
   rm -rf /var/lib/apt/lists/*
 
 # Options for the downloads below. They fetch large archives (the XWiki WAR and the LibreOffice one weigh a few hundred
@@ -85,24 +86,31 @@ ENV CURL_OPTIONS="-fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-ti
 # automatically by BuildKit and the Docker Official Images infrastructure builds with the classic builder, where it
 # would expand to the empty string. We install into /opt and symlink /opt/libreoffice, which is one of the paths XWiki
 # (through JODConverter) probes to locate the LibreOffice installation automatically, so no extra configuration is
-# needed.
+# needed. The deb packages install into /opt/libreoffice<major>.<minor>, so the symlink target is derived from
+# LIBREOFFICE_VERSION by stripping its patch component rather than by globbing /opt. The -n flag of ln is what makes it
+# replace /opt/libreoffice itself: without it, ln dereferences an already-existing symlink to a directory and creates
+# the new link inside that directory instead. We then check that the symlink resolves to an actual soffice binary:
+# since it is the only thing making JODConverter find LibreOffice, an installation landing elsewhere must fail the
+# build rather than produce an image where office import/export silently doesn't work.
 ENV LIBREOFFICE_VERSION="$libreofficeVersion"
 ENV LIBREOFFICE_SHA256_AMD64="$libreofficeSha256Amd64"
 ENV LIBREOFFICE_SHA256_ARM64="$libreofficeSha256Arm64"
 ENV LIBREOFFICE_URL_PREFIX="https://download.documentfoundation.org/libreoffice/stable/\${LIBREOFFICE_VERSION}/deb"
-RUN LO_ARCH="\$(dpkg --print-architecture)" && \\
+RUN set -eux; \\
+  LO_ARCH="\$(dpkg --print-architecture)"; \\
   case "\$LO_ARCH" in \\
     amd64) LO_ARCH_DIR=x86_64; LO_ARCH_FILE=x86-64; LO_SHA256=\$LIBREOFFICE_SHA256_AMD64 ;; \\
     arm64) LO_ARCH_DIR=aarch64; LO_ARCH_FILE=aarch64; LO_SHA256=\$LIBREOFFICE_SHA256_ARM64 ;; \\
     *) echo "Unsupported architecture [\$LO_ARCH] for the LibreOffice installation" >&2; exit 1 ;; \\
-  esac && \\
-  LO_ARCHIVE="LibreOffice_\${LIBREOFFICE_VERSION}_Linux_\${LO_ARCH_FILE}_deb.tar.gz" && \\
-  curl \$CURL_OPTIONS "\${LIBREOFFICE_URL_PREFIX}/\${LO_ARCH_DIR}/\${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz && \\
-  echo "\$LO_SHA256 /tmp/libreoffice.tar.gz" | sha256sum -c - && \\
-  mkdir -p /tmp/libreoffice && \\
-  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz && \\
-  dpkg -i /tmp/libreoffice/LibreOffice_\${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb && \\
-  ln -fs \$(ls -d /opt/libreoffice*) /opt/libreoffice && \\
+  esac; \\
+  LO_ARCHIVE="LibreOffice_\${LIBREOFFICE_VERSION}_Linux_\${LO_ARCH_FILE}_deb.tar.gz"; \\
+  curl \$CURL_OPTIONS "\${LIBREOFFICE_URL_PREFIX}/\${LO_ARCH_DIR}/\${LO_ARCHIVE}" -o /tmp/libreoffice.tar.gz; \\
+  echo "\$LO_SHA256 */tmp/libreoffice.tar.gz" | sha256sum --strict -c -; \\
+  mkdir -p /tmp/libreoffice; \\
+  tar -C /tmp/libreoffice -xf /tmp/libreoffice.tar.gz; \\
+  dpkg -i /tmp/libreoffice/LibreOffice_\${LIBREOFFICE_VERSION}*_Linux_*_deb/DEBS/*.deb; \\
+  ln -fns "/opt/libreoffice\${LIBREOFFICE_VERSION%.*}" /opt/libreoffice; \\
+  test -x /opt/libreoffice/program/soffice; \\
   rm -rf /tmp/libreoffice /tmp/libreoffice.tar.gz
 
 # Install XWiki as the ROOT webapp context in Tomcat
@@ -111,12 +119,13 @@ RUN LO_ARCH="\$(dpkg --print-architecture)" && \\
 ENV XWIKI_VERSION="$xwikiVersion"
 ENV XWIKI_URL_PREFIX "https://maven.xwiki.org/releases/org/xwiki/platform/xwiki-platform-distribution-war/\${XWIKI_VERSION}"
 ENV XWIKI_DOWNLOAD_SHA256 $xwikiSha256
-RUN rm -rf /usr/local/tomcat/webapps/* && \\
-  mkdir -p /usr/local/tomcat/temp && \\
-  mkdir -p /usr/local/xwiki/data && \\
-  curl \$CURL_OPTIONS "\${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-\${XWIKI_VERSION}.war" -o xwiki.war && \\
-  echo "\$XWIKI_DOWNLOAD_SHA256 xwiki.war" | sha256sum -c - && \\
-  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war && \\
+RUN set -eux; \\
+  rm -rf /usr/local/tomcat/webapps/*; \\
+  mkdir -p /usr/local/tomcat/temp; \\
+  mkdir -p /usr/local/xwiki/data; \\
+  curl \$CURL_OPTIONS "\${XWIKI_URL_PREFIX}/xwiki-platform-distribution-war-\${XWIKI_VERSION}.war" -o xwiki.war; \\
+  echo "\$XWIKI_DOWNLOAD_SHA256 *xwiki.war" | sha256sum --strict -c -; \\
+  unzip -d /usr/local/tomcat/webapps/ROOT xwiki.war; \\
   rm -f xwiki.war
 
 # Copy the JDBC driver in the XWiki webapp
@@ -129,25 +138,28 @@ if (db == 'mysql') {
   println "ENV MYSQL_JDBC_PREFIX=\"https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/\${MYSQL_JDBC_VERSION}\""
   println "ENV MYSQL_JDBC_ARTIFACT=\"mysql-connector-j-\${MYSQL_JDBC_VERSION}.jar\""
   println "ENV MYSQL_JDBC_TARGET=\"/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/\${MYSQL_JDBC_ARTIFACT}\""
-  println "RUN curl \$CURL_OPTIONS \"\${MYSQL_JDBC_PREFIX}/\${MYSQL_JDBC_ARTIFACT}\" -o \$MYSQL_JDBC_TARGET && \\"
-  print "  echo \"\$MYSQL_JDBC_SHA256 \$MYSQL_JDBC_TARGET\" | sha256sum -c -"
+  println "RUN set -eux; \\"
+  println "  curl \$CURL_OPTIONS \"\${MYSQL_JDBC_PREFIX}/\${MYSQL_JDBC_ARTIFACT}\" -o \$MYSQL_JDBC_TARGET; \\"
+  print "  echo \"\$MYSQL_JDBC_SHA256 *\$MYSQL_JDBC_TARGET\" | sha256sum --strict -c -"
 } else if (db == 'mariadb') {
   println "ENV MARIADB_JDBC_VERSION=\"$mariadbJDBCVersion\""
   println "ENV MARIADB_JDBC_SHA256=\"$mariadbJDBCSha256\""
   println "ENV MARIADB_JDBC_PREFIX=\"https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/\${MARIADB_JDBC_VERSION}\""
   println "ENV MARIADB_JDBC_ARTIFACT=\"mariadb-java-client-\${MARIADB_JDBC_VERSION}.jar\""
   println "ENV MARIADB_JDBC_TARGET=\"/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/\${MARIADB_JDBC_ARTIFACT}\""
-  println "RUN curl \$CURL_OPTIONS \"\${MARIADB_JDBC_PREFIX}/\${MARIADB_JDBC_ARTIFACT}\" -o \$MARIADB_JDBC_TARGET && \\"
-  print "  echo \"\$MARIADB_JDBC_SHA256 \$MARIADB_JDBC_TARGET\" | sha256sum -c -"
+  println "RUN set -eux; \\"
+  println "  curl \$CURL_OPTIONS \"\${MARIADB_JDBC_PREFIX}/\${MARIADB_JDBC_ARTIFACT}\" -o \$MARIADB_JDBC_TARGET; \\"
+  print "  echo \"\$MARIADB_JDBC_SHA256 *\$MARIADB_JDBC_TARGET\" | sha256sum --strict -c -"
 } else if (db == 'postgres') {
   println "ENV POSTGRES_JDBC_VERSION=\"$postgresJDBCVersion\""
   println "ENV POSTGRES_JDBC_SHA256=\"$postgresJDBCSha256\""
   println "ENV POSTGRES_JDBC_PREFIX=\"https://repo1.maven.org/maven2/org/postgresql/postgresql/\${POSTGRES_JDBC_VERSION}\""
   println "ENV POSTGRES_JDBC_ARTIFACT=\"postgresql-\${POSTGRES_JDBC_VERSION}.jar\""
   println "ENV POSTGRES_JDBC_TARGET=\"/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/\${POSTGRES_JDBC_ARTIFACT}\""
-  println "RUN curl \$CURL_OPTIONS \"\${POSTGRES_JDBC_PREFIX}/\${POSTGRES_JDBC_ARTIFACT}\" " +
-    "-o \$POSTGRES_JDBC_TARGET && \\"
-  print "  echo \"\$POSTGRES_JDBC_SHA256 \$POSTGRES_JDBC_TARGET\" | sha256sum -c -"
+  println "RUN set -eux; \\"
+  println "  curl \$CURL_OPTIONS \"\${POSTGRES_JDBC_PREFIX}/\${POSTGRES_JDBC_ARTIFACT}\" " +
+    "-o \$POSTGRES_JDBC_TARGET; \\"
+  print "  echo \"\$POSTGRES_JDBC_SHA256 *\$POSTGRES_JDBC_TARGET\" | sha256sum --strict -c -"
 } %>
 
 # Configure Tomcat. For example set the memory for the Tomcat JVM since the default value is too small for XWiki
@@ -162,11 +174,12 @@ COPY xwiki/hibernate.cfg.xml /usr/local/tomcat/webapps/ROOT/WEB-INF/hibernate.cf
 # version-specific logger levels it defines: the appender definition is inserted right after the opening
 # <configuration> tag and its reference right after the existing "stdout" one.
 COPY xwiki/logback-filelog-appender.xml xwiki/logback-filelog-ref.xml /tmp/
-RUN LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml && \\
+RUN set -eux; \\
+  LOGBACK=/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/logback.xml; \\
   sed -e \'/<configuration/r /tmp/logback-filelog-appender.xml\' \\
       -e \'/ref="stdout"/r /tmp/logback-filelog-ref.xml\' \\
-      "\$LOGBACK" > "\$LOGBACK.new" && \\
-  mv "\$LOGBACK.new" "\$LOGBACK" && \\
+      "\$LOGBACK" > "\$LOGBACK.new"; \\
+  mv "\$LOGBACK.new" "\$LOGBACK"; \\
   rm -f /tmp/logback-filelog-appender.xml /tmp/logback-filelog-ref.xml
 
 # Set a specific distribution id in XWiki for this docker packaging.


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XDOCKER-426

Applies the three suggestions [tianon made](https://github.com/docker-library/official-images/pull/21937#issuecomment-5121401376) while reviewing the Docker Official Images PR for XWiki 18.6.0. None of them is a bug users can hit today, but the first turns a silent runtime failure into a build failure and the other two align the file with the shell conventions used across the official images.

As always the change is made in `template/Dockerfile` and the 12 version/variant directories are regenerated with `./gradlew`.

### 1. Derive the LibreOffice symlink from the version, and verify it

```diff
-  ln -fs $(ls -d /opt/libreoffice*) /opt/libreoffice
+  ln -fns "/opt/libreoffice${LIBREOFFICE_VERSION%.*}" /opt/libreoffice; \
+  test -x /opt/libreoffice/program/soffice
```

The command substitution was unquoted, so word splitting would break the `ln` invocation if the glob ever matched more than one path.

More importantly nothing verified that the symlink actually pointed at a LibreOffice installation, even though it is the only thing making JODConverter find LibreOffice — so an installation landing elsewhere would produce an image that builds fine and silently fails office import/export at runtime. `test -x` resolves through the symlink and now fails the build instead.

The Document Foundation packages install into `/opt/libreoffice<major>.<minor>`, and `updateLibreOffice` only ever writes a three-component version (its listing regex is `href="(\d+)\.(\d+)\.(\d+)\/"`), so stripping the patch component always yields the right directory — no filesystem inspection needed.

The `-n` on `ln` goes beyond the review comment. Testing the guard turned up that without it, `ln -fs` *dereferences* an already-existing `/opt/libreoffice` symlink-to-directory and creates the new link **inside** that directory, silently leaving the original pointing at the old install:

```
$ ln -fs /opt/libreoffice26.0 /opt/libreoffice     # /opt/libreoffice -> /opt/libreoffice25.8 already
$ readlink /opt/libreoffice
/opt/libreoffice25.8                               # unchanged
$ ls /opt/libreoffice25.8/libreoffice26.0          # stray link created here instead
```

That cannot happen in this Dockerfile as written (the symlink is created once, in a layer where it does not yet exist), but `-n` makes the command mean what it says regardless of prior state, which matters precisely because `test -x` would otherwise pass against the stale target.

### 2. `set -eux;` instead of `&&` chaining

Beyond being the Docker Official Images house style, this is more robust to later edits: with `&&` chaining, adding a line and forgetting its trailing `&&` silently ignores that command's failure, whereas `set -e` always propagates it. `set -x` also traces each command in the build log, which helps when a build fails on one of the transient network errors these large downloads are prone to.

Applied to every multi-command `RUN` block rather than only the two quoted in the review, so the file doesn't end up with mixed styles. Single-command `RUN`s are left alone (nothing to chain). `contrib/solr/Dockerfile` is untouched: it is not generated from `template/` and not part of the official image.

### 3. Conventional binary-mode checksum format

```diff
-  echo "$SHA256 file" | sha256sum -c -
+  echo "$SHA256 *file" | sha256sum --strict -c -
```

Applied to all five verifications (LibreOffice, the XWiki WAR, and the three JDBC drivers).

### Testing

`18/postgres-tomcat` built locally with `DOCKER_BUILDKIT=0` (the classic builder the Docker Official Images infrastructure uses, where `TARGETARCH` is empty). From the build log, with `set -x` now tracing each step:

```
+ dpkg --print-architecture
+ sha256sum --strict -c -          /tmp/libreoffice.tar.gz: OK
+ ln -fns /opt/libreoffice25.8 /opt/libreoffice
+ test -x /opt/libreoffice/program/soffice
+ sha256sum --strict -c -          xwiki.war: OK
+ sha256sum --strict -c -          postgresql-42.7.13.jar: OK
```

and in the resulting image, `/opt/libreoffice` → `/opt/libreoffice25.8` with `soffice --version` reporting `LibreOffice 25.8.7.3`, the JDBC driver present in `WEB-INF/lib` and XWiki deployed as ROOT.

The `test -x` guard was also checked to be non-vacuous: pointing the symlink at a version that isn't installed does fail the build. The generated CI workflow builds and inspects every version/variant combination.
