### PR TITLE
XDOCKER-427: XWiki is deployed twice when CONTEXT_PATH is set to something other than ROOT

### DIFF
--- a/16/mariadb-tomcat/xwiki/docker-entrypoint.sh
+++ b/16/mariadb-tomcat/xwiki/docker-entrypoint.sh
@@ -167,8 +167,15 @@ function configure() {
   if [ "$CONTEXT_PATH" == "ROOT" ]; then
     xwiki_set_cfg 'xwiki.webapppath' ''
   else
+    # Copy instead of moving, so that files bind-mounted into the target context directory (e.g. a custom
+    # WEB-INF/classes/logback.xml) survive: Docker creates that directory before this script runs, and "mv" cannot
+    # merge into an existing directory. "--update=none" keeps the mounted files rather than overwriting them.
     mkdir -p -v /usr/local/tomcat/webapps/$CONTEXT_PATH
     cp -a --update=none /usr/local/tomcat/webapps/ROOT/.  /usr/local/tomcat/webapps/$CONTEXT_PATH/
+    # Tomcat auto-deploys every directory under webapps/, so ROOT must not be left behind: XWiki would then be
+    # deployed twice in the same JVM and the second context would fail to start (e.g. on the "org.xwiki.infinispan"
+    # JMX domain already being registered).
+    rm -rf /usr/local/tomcat/webapps/ROOT
   fi
 
   # When DB_PORT is set, it's added to the host in the JDBC URL of hibernate.cfg.xml, so that a DB listening on a

--- a/16/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/16/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -167,8 +167,15 @@ function configure() {
   if [ "$CONTEXT_PATH" == "ROOT" ]; then
     xwiki_set_cfg 'xwiki.webapppath' ''
   else
+    # Copy instead of moving, so that files bind-mounted into the target context directory (e.g. a custom
+    # WEB-INF/classes/logback.xml) survive: Docker creates that directory before this script runs, and "mv" cannot
+    # merge into an existing directory. "--update=none" keeps the mounted files rather than overwriting them.
     mkdir -p -v /usr/local/tomcat/webapps/$CONTEXT_PATH
     cp -a --update=none /usr/local/tomcat/webapps/ROOT/.  /usr/local/tomcat/webapps/$CONTEXT_PATH/
+    # Tomcat auto-deploys every directory under webapps/, so ROOT must not be left behind: XWiki would then be
+    # deployed twice in the same JVM and the second context would fail to start (e.g. on the "org.xwiki.infinispan"
+    # JMX domain already being registered).
+    rm -rf /usr/local/tomcat/webapps/ROOT
   fi
 
   # When DB_PORT is set, it's added to the host in the JDBC URL of hibernate.cfg.xml, so that a DB listening on a

--- a/16/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/16/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -167,8 +167,15 @@ function configure() {
   if [ "$CONTEXT_PATH" == "ROOT" ]; then
     xwiki_set_cfg 'xwiki.webapppath' ''
   else
+    # Copy instead of moving, so that files bind-mounted into the target context directory (e.g. a custom
+    # WEB-INF/classes/logback.xml) survive: Docker creates that directory before this script runs, and "mv" cannot
+    # merge into an existing directory. "--update=none" keeps the mounted files rather than overwriting them.
     mkdir -p -v /usr/local/tomcat/webapps/$CONTEXT_PATH
     cp -a --update=none /usr/local/tomcat/webapps/ROOT/.  /usr/local/tomcat/webapps/$CONTEXT_PATH/
+    # Tomcat auto-deploys every directory under webapps/, so ROOT must not be left behind: XWiki would then be
+    # deployed twice in the same JVM and the second context would fail to start (e.g. on the "org.xwiki.infinispan"
+    # JMX domain already being registered).
+    rm -rf /usr/local/tomcat/webapps/ROOT
   fi
 
   # When DB_PORT is set, it's added to the host in the JDBC URL of hibernate.cfg.xml, so that a DB listening on a

--- a/17/mariadb-tomcat/xwiki/docker-entrypoint.sh
+++ b/17/mariadb-tomcat/xwiki/docker-entrypoint.sh
@@ -167,8 +167,15 @@ function configure() {
   if [ "$CONTEXT_PATH" == "ROOT" ]; then
     xwiki_set_cfg 'xwiki.webapppath' ''
   else
+    # Copy instead of moving, so that files bind-mounted into the target context directory (e.g. a custom
+    # WEB-INF/classes/logback.xml) survive: Docker creates that directory before this script runs, and "mv" cannot
+    # merge into an existing directory. "--update=none" keeps the mounted files rather than overwriting them.
     mkdir -p -v /usr/local/tomcat/webapps/$CONTEXT_PATH
     cp -a --update=none /usr/local/tomcat/webapps/ROOT/.  /usr/local/tomcat/webapps/$CONTEXT_PATH/
+    # Tomcat auto-deploys every directory under webapps/, so ROOT must not be left behind: XWiki would then be
+    # deployed twice in the same JVM and the second context would fail to start (e.g. on the "org.xwiki.infinispan"
+    # JMX domain already being registered).
+    rm -rf /usr/local/tomcat/webapps/ROOT
   fi
 
   # When DB_PORT is set, it's added to the host in the JDBC URL of hibernate.cfg.xml, so that a DB listening on a

--- a/17/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/17/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -167,8 +167,15 @@ function configure() {
   if [ "$CONTEXT_PATH" == "ROOT" ]; then
     xwiki_set_cfg 'xwiki.webapppath' ''
   else
+    # Copy instead of moving, so that files bind-mounted into the target context directory (e.g. a custom
+    # WEB-INF/classes/logback.xml) survive: Docker creates that directory before this script runs, and "mv" cannot
+    # merge into an existing directory. "--update=none" keeps the mounted files rather than overwriting them.
     mkdir -p -v /usr/local/tomcat/webapps/$CONTEXT_PATH
     cp -a --update=none /usr/local/tomcat/webapps/ROOT/.  /usr/local/tomcat/webapps/$CONTEXT_PATH/
+    # Tomcat auto-deploys every directory under webapps/, so ROOT must not be left behind: XWiki would then be
+    # deployed twice in the same JVM and the second context would fail to start (e.g. on the "org.xwiki.infinispan"
+    # JMX domain already being registered).
+    rm -rf /usr/local/tomcat/webapps/ROOT
   fi
 
   # When DB_PORT is set, it's added to the host in the JDBC URL of hibernate.cfg.xml, so that a DB listening on a

--- a/17/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/17/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -167,8 +167,15 @@ function configure() {
   if [ "$CONTEXT_PATH" == "ROOT" ]; then
     xwiki_set_cfg 'xwiki.webapppath' ''
   else
+    # Copy instead of moving, so that files bind-mounted into the target context directory (e.g. a custom
+    # WEB-INF/classes/logback.xml) survive: Docker creates that directory before this script runs, and "mv" cannot
+    # merge into an existing directory. "--update=none" keeps the mounted files rather than overwriting them.
     mkdir -p -v /usr/local/tomcat/webapps/$CONTEXT_PATH
     cp -a --update=none /usr/local/tomcat/webapps/ROOT/.  /usr/local/tomcat/webapps/$CONTEXT_PATH/
+    # Tomcat auto-deploys every directory under webapps/, so ROOT must not be left behind: XWiki would then be
+    # deployed twice in the same JVM and the second context would fail to start (e.g. on the "org.xwiki.infinispan"
+    # JMX domain already being registered).
+    rm -rf /usr/local/tomcat/webapps/ROOT
   fi
 
   # When DB_PORT is set, it's added to the host in the JDBC URL of hibernate.cfg.xml, so that a DB listening on a

--- a/18.4/mariadb-tomcat/xwiki/docker-entrypoint.sh
+++ b/18.4/mariadb-tomcat/xwiki/docker-entrypoint.sh
@@ -167,8 +167,15 @@ function configure() {
   if [ "$CONTEXT_PATH" == "ROOT" ]; then
     xwiki_set_cfg 'xwiki.webapppath' ''
   else
+    # Copy instead of moving, so that files bind-mounted into the target context directory (e.g. a custom
+    # WEB-INF/classes/logback.xml) survive: Docker creates that directory before this script runs, and "mv" cannot
+    # merge into an existing directory. "--update=none" keeps the mounted files rather than overwriting them.
     mkdir -p -v /usr/local/tomcat/webapps/$CONTEXT_PATH
     cp -a --update=none /usr/local/tomcat/webapps/ROOT/.  /usr/local/tomcat/webapps/$CONTEXT_PATH/
+    # Tomcat auto-deploys every directory under webapps/, so ROOT must not be left behind: XWiki would then be
+    # deployed twice in the same JVM and the second context would fail to start (e.g. on the "org.xwiki.infinispan"
+    # JMX domain already being registered).
+    rm -rf /usr/local/tomcat/webapps/ROOT
   fi
 
   # When DB_PORT is set, it's added to the host in the JDBC URL of hibernate.cfg.xml, so that a DB listening on a

--- a/18.4/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/18.4/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -167,8 +167,15 @@ function configure() {
   if [ "$CONTEXT_PATH" == "ROOT" ]; then
     xwiki_set_cfg 'xwiki.webapppath' ''
   else
+    # Copy instead of moving, so that files bind-mounted into the target context directory (e.g. a custom
+    # WEB-INF/classes/logback.xml) survive: Docker creates that directory before this script runs, and "mv" cannot
+    # merge into an existing directory. "--update=none" keeps the mounted files rather than overwriting them.
     mkdir -p -v /usr/local/tomcat/webapps/$CONTEXT_PATH
     cp -a --update=none /usr/local/tomcat/webapps/ROOT/.  /usr/local/tomcat/webapps/$CONTEXT_PATH/
+    # Tomcat auto-deploys every directory under webapps/, so ROOT must not be left behind: XWiki would then be
+    # deployed twice in the same JVM and the second context would fail to start (e.g. on the "org.xwiki.infinispan"
+    # JMX domain already being registered).
+    rm -rf /usr/local/tomcat/webapps/ROOT
   fi
 
   # When DB_PORT is set, it's added to the host in the JDBC URL of hibernate.cfg.xml, so that a DB listening on a

--- a/18.4/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/18.4/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -167,8 +167,15 @@ function configure() {
   if [ "$CONTEXT_PATH" == "ROOT" ]; then
     xwiki_set_cfg 'xwiki.webapppath' ''
   else
+    # Copy instead of moving, so that files bind-mounted into the target context directory (e.g. a custom
+    # WEB-INF/classes/logback.xml) survive: Docker creates that directory before this script runs, and "mv" cannot
+    # merge into an existing directory. "--update=none" keeps the mounted files rather than overwriting them.
     mkdir -p -v /usr/local/tomcat/webapps/$CONTEXT_PATH
     cp -a --update=none /usr/local/tomcat/webapps/ROOT/.  /usr/local/tomcat/webapps/$CONTEXT_PATH/
+    # Tomcat auto-deploys every directory under webapps/, so ROOT must not be left behind: XWiki would then be
+    # deployed twice in the same JVM and the second context would fail to start (e.g. on the "org.xwiki.infinispan"
+    # JMX domain already being registered).
+    rm -rf /usr/local/tomcat/webapps/ROOT
   fi
 
   # When DB_PORT is set, it's added to the host in the JDBC URL of hibernate.cfg.xml, so that a DB listening on a

--- a/18/mariadb-tomcat/xwiki/docker-entrypoint.sh
+++ b/18/mariadb-tomcat/xwiki/docker-entrypoint.sh
@@ -167,8 +167,15 @@ function configure() {
   if [ "$CONTEXT_PATH" == "ROOT" ]; then
     xwiki_set_cfg 'xwiki.webapppath' ''
   else
+    # Copy instead of moving, so that files bind-mounted into the target context directory (e.g. a custom
+    # WEB-INF/classes/logback.xml) survive: Docker creates that directory before this script runs, and "mv" cannot
+    # merge into an existing directory. "--update=none" keeps the mounted files rather than overwriting them.
     mkdir -p -v /usr/local/tomcat/webapps/$CONTEXT_PATH
     cp -a --update=none /usr/local/tomcat/webapps/ROOT/.  /usr/local/tomcat/webapps/$CONTEXT_PATH/
+    # Tomcat auto-deploys every directory under webapps/, so ROOT must not be left behind: XWiki would then be
+    # deployed twice in the same JVM and the second context would fail to start (e.g. on the "org.xwiki.infinispan"
+    # JMX domain already being registered).
+    rm -rf /usr/local/tomcat/webapps/ROOT
   fi
 
   # When DB_PORT is set, it's added to the host in the JDBC URL of hibernate.cfg.xml, so that a DB listening on a

--- a/18/mysql-tomcat/xwiki/docker-entrypoint.sh
+++ b/18/mysql-tomcat/xwiki/docker-entrypoint.sh
@@ -167,8 +167,15 @@ function configure() {
   if [ "$CONTEXT_PATH" == "ROOT" ]; then
     xwiki_set_cfg 'xwiki.webapppath' ''
   else
+    # Copy instead of moving, so that files bind-mounted into the target context directory (e.g. a custom
+    # WEB-INF/classes/logback.xml) survive: Docker creates that directory before this script runs, and "mv" cannot
+    # merge into an existing directory. "--update=none" keeps the mounted files rather than overwriting them.
     mkdir -p -v /usr/local/tomcat/webapps/$CONTEXT_PATH
     cp -a --update=none /usr/local/tomcat/webapps/ROOT/.  /usr/local/tomcat/webapps/$CONTEXT_PATH/
+    # Tomcat auto-deploys every directory under webapps/, so ROOT must not be left behind: XWiki would then be
+    # deployed twice in the same JVM and the second context would fail to start (e.g. on the "org.xwiki.infinispan"
+    # JMX domain already being registered).
+    rm -rf /usr/local/tomcat/webapps/ROOT
   fi
 
   # When DB_PORT is set, it's added to the host in the JDBC URL of hibernate.cfg.xml, so that a DB listening on a

--- a/18/postgres-tomcat/xwiki/docker-entrypoint.sh
+++ b/18/postgres-tomcat/xwiki/docker-entrypoint.sh
@@ -167,8 +167,15 @@ function configure() {
   if [ "$CONTEXT_PATH" == "ROOT" ]; then
     xwiki_set_cfg 'xwiki.webapppath' ''
   else
+    # Copy instead of moving, so that files bind-mounted into the target context directory (e.g. a custom
+    # WEB-INF/classes/logback.xml) survive: Docker creates that directory before this script runs, and "mv" cannot
+    # merge into an existing directory. "--update=none" keeps the mounted files rather than overwriting them.
     mkdir -p -v /usr/local/tomcat/webapps/$CONTEXT_PATH
     cp -a --update=none /usr/local/tomcat/webapps/ROOT/.  /usr/local/tomcat/webapps/$CONTEXT_PATH/
+    # Tomcat auto-deploys every directory under webapps/, so ROOT must not be left behind: XWiki would then be
+    # deployed twice in the same JVM and the second context would fail to start (e.g. on the "org.xwiki.infinispan"
+    # JMX domain already being registered).
+    rm -rf /usr/local/tomcat/webapps/ROOT
   fi
 
   # When DB_PORT is set, it's added to the host in the JDBC URL of hibernate.cfg.xml, so that a DB listening on a

--- a/template/xwiki/docker-entrypoint.sh
+++ b/template/xwiki/docker-entrypoint.sh
@@ -174,8 +174,15 @@ function configure() {
   if [ "\$CONTEXT_PATH" == "ROOT" ]; then
     xwiki_set_cfg 'xwiki.webapppath' ''
   else
+    # Copy instead of moving, so that files bind-mounted into the target context directory (e.g. a custom
+    # WEB-INF/classes/logback.xml) survive: Docker creates that directory before this script runs, and "mv" cannot
+    # merge into an existing directory. "--update=none" keeps the mounted files rather than overwriting them.
     mkdir -p -v /usr/local/tomcat/webapps/\$CONTEXT_PATH
     cp -a --update=none /usr/local/tomcat/webapps/ROOT/.  /usr/local/tomcat/webapps/\$CONTEXT_PATH/
+    # Tomcat auto-deploys every directory under webapps/, so ROOT must not be left behind: XWiki would then be
+    # deployed twice in the same JVM and the second context would fail to start (e.g. on the "org.xwiki.infinispan"
+    # JMX domain already being registered).
+    rm -rf /usr/local/tomcat/webapps/ROOT
   fi
 
   # When DB_PORT is set, it's added to the host in the JDBC URL of hibernate.cfg.xml, so that a DB listening on a


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XDOCKER-427

Reported on the forum: [XWiki deploying twice when CONTEXT_PATH variable is set up](https://forum.xwiki.org/t/xwiki-deploying-twice-when-context-path-variable-is-set-up/18732).

Setting `CONTEXT_PATH` to anything other than `ROOT` currently starts **two** XWiki webapps in the same Tomcat JVM. The second one to start dies with `The 'org.xwiki.infinispan' JMX domain is already in use` (hundreds of times in the log), `/` returns a 404, and only `/<CONTEXT_PATH>` works.

### Cause

`configure()` deploys a non-ROOT context by copying `webapps/ROOT` into `webapps/$CONTEXT_PATH`:

```sh
mkdir -p -v /usr/local/tomcat/webapps/$CONTEXT_PATH
cp -a --update=none /usr/local/tomcat/webapps/ROOT/.  /usr/local/tomcat/webapps/$CONTEXT_PATH/
```

That used to be a `mv` and became a merging copy in XDOCKER-402, so that a config file bind-mounted into the target context directory (a custom `WEB-INF/classes/logback.xml`) is not clobbered — Docker creates that directory before the entrypoint runs, and `mv` cannot merge into an existing directory.

The copy is right, but nothing removes `webapps/ROOT` afterwards and **Tomcat auto-deploys every directory under `webapps/`**, so both contexts get deployed. So this adds the missing `rm -rf`:

```diff
     mkdir -p -v /usr/local/tomcat/webapps/$CONTEXT_PATH
     cp -a --update=none /usr/local/tomcat/webapps/ROOT/.  /usr/local/tomcat/webapps/$CONTEXT_PATH/
+    rm -rf /usr/local/tomcat/webapps/ROOT
```

plus comments recording why the copy is a copy and why `ROOT` has to go, since the two are easy to "simplify" back into a bug. As always the change is made in `template/xwiki/docker-entrypoint.sh` and the 12 version/variant directories are regenerated with `./gradlew`.

Note this leaves the behaviour of a mount placed inside `webapps/ROOT` itself unchanged from before XDOCKER-402: `rm -rf` fails on a busy mount point exactly like `mv` did, and `set -e` aborts the start with the error visible. Mounts belong in `webapps/$CONTEXT_PATH`.

### Affected versions

Every image generated after XDOCKER-402 landed (19 March 2026): 18.2.0 and later, 17.10.6 and later, all 18.4.x, and 16.10.18 and later.

### Executed Tests

No Maven build here. `./gradlew` regenerates cleanly (so `gradlew-check` passes), `bash -n` is clean on all 12 generated entrypoints, and no line exceeds 120 characters.

Verified against the published `xwiki:18.4.0-postgres-tomcat` image with `CONTEXT_PATH=wiki`, bind-mounting the entrypoint generated by this branch over `/usr/local/bin/docker-entrypoint.sh`:

| | Tomcat deploys | `webapps/` | `JMX domain is already in use` log lines |
|---|---|---|---|
| before | `wiki` **and** `ROOT` | `ROOT wiki` | 284 |
| after | `wiki` only | `wiki` | 0 |

Also confirmed on both base images (`tomcat:9-jre21` and `tomcat:10-jre21`, coreutils 9.4) that the merging copy still preserves a pre-existing bind-mounted `WEB-INF/classes/logback.xml`, i.e. the XDOCKER-402 scenario keeps working.

### Clarifications

Two follow-ups deliberately left out of this fix:

- **Multi-level context paths still don't work**, although XDOCKER-402 added a `mkdir -p` for them. Tomcat only deploys the immediate children of `webapps/`, so `CONTEXT_PATH=foo/bar` produces an empty webapp at `/foo` and nothing at `/foo/bar` (verified). Tomcat's convention is a `foo#bar` directory name.
- The copy still **duplicates the whole webapp (~400MB) on first start**. Both this and the point above would be solved properly by shipping the webapp outside the auto-deploy directory and generating a Tomcat context descriptor (`conf/Catalina/localhost/<context>.xml` with a `docBase`) instead of copying — but that is a bigger change than this regression fix deserves.

### Expected merging strategy

Prefers squash: Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
