### PR TITLE
[Misc] Update actions/checkout to v7 and let Renovate update the workflow template

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,5 +21,32 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  // .github/workflows/docker-build.yml is generated from template-github/docker-build.yml, so updating it directly
+  // produces a Pull Request that the Gradlew Check action rejects and that the next './gradlew' run reverts. The two
+  // rules below move the updates to the template: the custom manager reads the action versions from it (the native
+  // github-actions manager can't, since the template is not valid YAML before the tokens are expanded), and the
+  // package rule stops the generated file from being updated on its own.
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^template-github/.+\\.yml$/"
+      ],
+      "matchStrings": [
+        "uses:\\s+(?<depName>[^\\s@]+)@(?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      // The same versioning as the native github-actions manager, so that a 'v4' pin becomes 'v7' rather than 'v7.0.1'.
+      "versioningTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchFileNames": [
+        ".github/workflows/docker-build.yml"
+      ],
+      "enabled": false
+    }
   ]
 }

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Build the image
         working-directory: ${{ matrix.version }}/${{ matrix.variant }}

--- a/.github/workflows/gradlew-check.yml
+++ b/.github/workflows/gradlew-check.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/template-github/docker-build.yml
+++ b/template-github/docker-build.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Build the image
         working-directory: \${{ matrix.version }}/\${{ matrix.variant }}


### PR DESCRIPTION
Supersedes #86.

#86 (Renovate) bumped `actions/checkout` to v7 in `.github/workflows/docker-build.yml`, but that file is **generated** from `template-github/docker-build.yml`, which still pinned v4. Merging it would have made `Gradlew Check` fail on `master` (it regenerates the file and diffs), and the next `./gradlew` run would have silently reverted the bump. Its green checks were misleading: the `pull_request` trigger for `Gradlew Check` was only added in 187b5c3, after #86's head was pushed, so that check never ran there.

## Changes

* Bump `actions/checkout` to v7 in `template-github/docker-build.yml` and in `.github/workflows/gradlew-check.yml` (the latter is not generated), and regenerate `.github/workflows/docker-build.yml` with `./gradlew`.
* Teach Renovate about the template tree, so this class of unmergeable Pull Request doesn't recur:
  * a **custom manager** reading `uses:` lines from `template-github/**.yml`;
  * a **package rule** disabling updates to the generated `.github/workflows/docker-build.yml`.

## Notes on the Renovate config

* A regex custom manager rather than extending the native `github-actions` manager's file patterns, because the template is **not valid YAML** before token expansion — `$pathFilters` sits at column 0 under `paths:` — so the YAML-parsing native manager would silently extract nothing.
* `datasourceTemplate: github-tags` + `versioningTemplate: docker` mirrors the native manager, keeping the repo's major-only pins (`v4` -> `v7`, not `v7.0.1`).
* `packageRules` + `matchFileNames` rather than top-level `ignorePaths`, which would have replaced `config:base`'s default ignore list instead of adding to it.

## Verification

* `./gradlew` is idempotent on the result — a second run produces no diff, so `Gradlew Check` passes.
* `renovate-config-validator` passes with **renovate@44**, the version running on this repo (per #86's debug blob). Worth knowing for future config edits: a plain `npx renovate` may resolve an older 37.x, which rejects `managerFilePatterns` (renamed from `fileMatch` in v41).
* The `matchStrings` regex was checked to extract `actions/checkout` from the template, and the file pattern to not match the generated path. A full `renovate --platform=local` extraction was not run — renovate@44 requires Node 24.
* No line exceeds 120 characters.

Left alone as out of scope: `renovate-config-validator` also flags `extends: config:base` as deprecated in favour of `config:recommended`. It's pre-existing and Renovate auto-migrates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
